### PR TITLE
Track states

### DIFF
--- a/include/LCHelpers/ClusterHelper.h
+++ b/include/LCHelpers/ClusterHelper.h
@@ -94,14 +94,15 @@ public:
      *  @brief  Get the distance of closest approach between the projected track direction at calorimeter and the hits within a cluster.
      *          Note that only a specified number of layers are examined.
      * 
-     *  @param  pTrack address of the track
+     *  @param  pT track, trackState or vector of trackStates, for a Track the TrackStateAtCalorimeter is used
      *  @param  pCluster address of the cluster
      *  @param  maxSearchLayer the maximum pseudolayer to examine
      *  @param  parallelDistanceCut maximum allowed projection of track-cluster separation along track direction
      *  @param  minTrackClusterCosAngle min cos(angle) between track and cluster initial direction
      *  @param  trackClusterDistance to receive the track cluster distance
      */
-    static pandora::StatusCode GetTrackClusterDistance(const pandora::Track *const pTrack, const pandora::Cluster *const pCluster,
+    template<typename T>
+    static pandora::StatusCode GetTrackClusterDistance(const T *const pT, const pandora::Cluster *const pCluster,
         const unsigned int maxSearchLayer, const float parallelDistanceCut, const float minTrackClusterCosAngle, float &trackClusterDistance);
 
     /**

--- a/include/LCObjects/LCTrack.h
+++ b/include/LCObjects/LCTrack.h
@@ -72,22 +72,16 @@ public:
      *
      *  @param  parameters the parameters to pass in constructor
      *  @param  fileReader the file reader, used to extract any additional parameters from file
-
-     * Doesn't work for vectors of trackStates
-
      */
-    pandora::StatusCode Read(Parameters &, pandora::FileReader &) const { return pandora::STATUS_CODE_SUCCESS; }
+    pandora::StatusCode Read(Parameters &, pandora::FileReader &) const;
 
     /**
      *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
      *
      *  @param  pObject the address of the object to persist
      *  @param  fileWriter the file writer
-
-     * Doesn't work for vectors of trackStates
-
      */
-    pandora::StatusCode Write(const Object *const , pandora::FileWriter &) const { return pandora::STATUS_CODE_SUCCESS; }
+    pandora::StatusCode Write(const Object *const , pandora::FileWriter &) const;
 
     /**
      *  @brief  Create an object with the given parameters
@@ -138,59 +132,88 @@ inline pandora::StatusCode LCTrackFactory::Create(const Parameters &parameters, 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-// inline pandora::StatusCode LCTrackFactory::Read(Parameters &parameters, pandora::FileReader &fileReader) const
-// {
-//     // ATTN: To receive this call-back must have already set file reader track factory to this factory
-//     LCTrackStates trackStates;
+inline pandora::StatusCode LCTrackFactory::Read(Parameters &parameters, pandora::FileReader &fileReader) const
+{
+    // ATTN: To receive this call-back must have already set file reader track factory to this factory
+    LCInputTrackStates trackStates;
+    int nTrackStates;
+    if (pandora::BINARY == fileReader.GetFileType())
+    {
+        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader&>(fileReader));
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(nTrackStates));
+        for (int i = 0; i < nTrackStates; ++i)
+        {
+            pandora::TrackState trackState(0.0,0.0,0.0,0.0,0.0,0.0);
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trackState));
+            trackStates.push_back( pandora::InputTrackState(trackState) );
+        }
+    }
+    else if (pandora::XML == fileReader.GetFileType())
+    {
+        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader&>(fileReader));
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("NumberOfTrackStates", nTrackStates));
+        for (int i = 0; i < nTrackStates; ++i)
+        {
+            pandora::TrackState trackState(0.0,0.0,0.0,0.0,0.0,0.0);
+            std::stringstream trackStateName;
+            trackStateName << "TrackState" << i;
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable(trackStateName.str(), trackState));
+            trackStates.push_back( pandora::InputTrackState(trackState) );
+        }
+    }
+    else
+    {
+        return pandora::STATUS_CODE_INVALID_PARAMETER;
+    }
 
-//     if (pandora::BINARY == fileReader.GetFileType())
-//     {
-//         pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader&>(fileReader));
-//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trackStates));
-//     }
-//     else if (pandora::XML == fileReader.GetFileType())
-//     {
-//         pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader&>(fileReader));
-//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("TrackStates", trackStates));
-//     }
-//     else
-//     {
-//         return pandora::STATUS_CODE_INVALID_PARAMETER;
-//     }
+    LCTrackParameters &lcTrackParameters(dynamic_cast<LCTrackParameters&>(parameters));
+    lcTrackParameters.m_trackStates = trackStates;
 
-//     LCTrackParameters &lcTrackParameters(dynamic_cast<LCTrackParameters&>(parameters));
-//     lcTrackParameters.m_trackStates = trackStates;
-
-//     return pandora::STATUS_CODE_SUCCESS;
-// }
+    return pandora::STATUS_CODE_SUCCESS;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-// inline pandora::StatusCode LCTrackFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
-// {
-//     // ATTN: To receive this call-back must have already set file writer track factory to this factory
-//     const LCTrack *const pLCTrack(dynamic_cast<const LCTrack*>(pObject));
+inline pandora::StatusCode LCTrackFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
+{
+    // ATTN: To receive this call-back must have already set file writer track factory to this factory
+    const LCTrack *const pLCTrack(dynamic_cast<const LCTrack*>(pObject));
 
-//     if (!pLCTrack)
-//         return pandora::STATUS_CODE_INVALID_PARAMETER;
+    if (!pLCTrack)
+        return pandora::STATUS_CODE_INVALID_PARAMETER;
 
-//     if (pandora::BINARY == fileWriter.GetFileType())
-//     {
-//         pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter&>(fileWriter));
-//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLCTrack->GetTrackStates()));
-//     }
-//     else if (pandora::XML == fileWriter.GetFileType())
-//     {
-//         pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter&>(fileWriter));
-//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("TrackStates", pLCTrack->GetTrackStates()));
-//     }
-//     else
-//     {
-//         return pandora::STATUS_CODE_INVALID_PARAMETER;
-//     }
+    const LCTrackStates& trackStates = pLCTrack->GetTrackStates();
+    int nTrackStates = trackStates.size();
 
-//     return pandora::STATUS_CODE_SUCCESS;
-// }
+    if (pandora::BINARY == fileWriter.GetFileType())
+    {
+        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter&>(fileWriter));
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(nTrackStates));
+        for (auto const& trackState : trackStates)
+        {
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(trackState));
+        }
+    }
+    else if (pandora::XML == fileWriter.GetFileType())
+    {
+        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter&>(fileWriter));
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("NumberOfTrackStates", nTrackStates));
+        int trackStateCounter=0;
+        for (auto const& trackState : trackStates)
+        {
+          std::stringstream trackStateName;
+          trackStateName << "TrackState" << trackStateCounter;
+          PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable(trackStateName.str(), trackState));
+          ++trackStateCounter;
+        }
+    }
+    else
+    {
+        return pandora::STATUS_CODE_INVALID_PARAMETER;
+    }
+
+    return pandora::STATUS_CODE_SUCCESS;
+}
 
 }//namespace
 

--- a/include/LCObjects/LCTrack.h
+++ b/include/LCObjects/LCTrack.h
@@ -1,0 +1,199 @@
+/**
+ * @file LCContent/LCObjects/include/LCTrack.h
+ *
+ * @brief Header file for LC Track class
+ *
+ */
+
+#ifndef LC_TRACK_H
+#define LC_TRACK_H 1
+
+#include "Objects/Track.h"
+#include "Api/PandoraApi.h"
+
+#include "Pandora/ObjectCreation.h"
+#include "Pandora/PandoraObjectFactories.h"
+
+#include "Persistency/BinaryFileReader.h"
+#include "Persistency/BinaryFileWriter.h"
+#include "Persistency/XmlFileReader.h"
+#include "Persistency/XmlFileWriter.h"
+
+
+namespace lc_content
+{
+
+typedef std::vector<pandora::InputTrackState> LCInputTrackStates;
+typedef std::vector<pandora::TrackState> LCTrackStates;
+
+
+/**
+ *  @brief  LCTrack Parameters, allow multiple track states at the calorimeter
+ */
+class LCTrackParameters : public object_creation::Track::Parameters
+{
+public:
+    LCInputTrackStates m_trackStates;       ///< Vector of TrackStates
+};
+
+/**
+ *  @brief  LCTrack extension of the Track class for LC-content
+ */
+class LCTrack: public object_creation::Track::Object
+{
+
+public:
+    LCTrack(const LCTrackParameters &parameters);
+    virtual ~LCTrack() {};
+
+    const LCTrackStates &GetTrackStates() const;
+
+protected:
+
+    LCTrackStates m_trackStates;
+
+};
+
+/**
+ *  @brief  LCTrackFactory responsible for LCTrack creation
+ */
+class LCTrackFactory : public pandora::ObjectFactory<object_creation::Track::Parameters, object_creation::Track::Object>
+{
+public:
+    /**
+     *  @brief  Create new parameters instance on the heap (memory-management to be controlled by user)
+     *
+     *  @return the address of the new parameters instance
+     */
+    Parameters *NewParameters() const;
+
+    /**
+     *  @brief  Read any additional (derived class only) object parameters from file using the specified file reader
+     *
+     *  @param  parameters the parameters to pass in constructor
+     *  @param  fileReader the file reader, used to extract any additional parameters from file
+
+     * Doesn't work for vectors of trackStates
+
+     */
+    pandora::StatusCode Read(Parameters &, pandora::FileReader &) const { return pandora::STATUS_CODE_SUCCESS; }
+
+    /**
+     *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
+     *
+     *  @param  pObject the address of the object to persist
+     *  @param  fileWriter the file writer
+
+     * Doesn't work for vectors of trackStates
+
+     */
+    pandora::StatusCode Write(const Object *const , pandora::FileWriter &) const { return pandora::STATUS_CODE_SUCCESS; }
+
+    /**
+     *  @brief  Create an object with the given parameters
+     *
+     *  @param  parameters the parameters to pass in constructor
+     *  @param  pObject to receive the address of the object created
+     */
+    pandora::StatusCode Create(const Parameters &parameters, const Object *&pObject) const;
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline LCTrack::LCTrack(const LCTrackParameters &parameters) :
+    object_creation::Track::Object(parameters),
+    m_trackStates()
+{
+    for (auto const& inputTrackState: parameters.m_trackStates ) {
+        m_trackStates.push_back( inputTrackState.Get() );
+    }
+
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LCTrackStates &LCTrack::GetTrackStates() const
+{
+    return m_trackStates;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline LCTrackFactory::Parameters *LCTrackFactory::NewParameters() const
+{
+    return (new LCTrackParameters);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline pandora::StatusCode LCTrackFactory::Create(const Parameters &parameters, const Object *&pObject) const
+{
+    const LCTrackParameters &lcTrackParameters(dynamic_cast<const LCTrackParameters&>(parameters));
+    pObject = new LCTrack(lcTrackParameters);
+
+    return pandora::STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+// inline pandora::StatusCode LCTrackFactory::Read(Parameters &parameters, pandora::FileReader &fileReader) const
+// {
+//     // ATTN: To receive this call-back must have already set file reader track factory to this factory
+//     LCTrackStates trackStates;
+
+//     if (pandora::BINARY == fileReader.GetFileType())
+//     {
+//         pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader&>(fileReader));
+//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trackStates));
+//     }
+//     else if (pandora::XML == fileReader.GetFileType())
+//     {
+//         pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader&>(fileReader));
+//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("TrackStates", trackStates));
+//     }
+//     else
+//     {
+//         return pandora::STATUS_CODE_INVALID_PARAMETER;
+//     }
+
+//     LCTrackParameters &lcTrackParameters(dynamic_cast<LCTrackParameters&>(parameters));
+//     lcTrackParameters.m_trackStates = trackStates;
+
+//     return pandora::STATUS_CODE_SUCCESS;
+// }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+// inline pandora::StatusCode LCTrackFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
+// {
+//     // ATTN: To receive this call-back must have already set file writer track factory to this factory
+//     const LCTrack *const pLCTrack(dynamic_cast<const LCTrack*>(pObject));
+
+//     if (!pLCTrack)
+//         return pandora::STATUS_CODE_INVALID_PARAMETER;
+
+//     if (pandora::BINARY == fileWriter.GetFileType())
+//     {
+//         pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter&>(fileWriter));
+//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLCTrack->GetTrackStates()));
+//     }
+//     else if (pandora::XML == fileWriter.GetFileType())
+//     {
+//         pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter&>(fileWriter));
+//         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("TrackStates", pLCTrack->GetTrackStates()));
+//     }
+//     else
+//     {
+//         return pandora::STATUS_CODE_INVALID_PARAMETER;
+//     }
+
+//     return pandora::STATUS_CODE_SUCCESS;
+// }
+
+}//namespace
+
+
+
+#endif // LC_TRACK_H

--- a/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
+++ b/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
@@ -204,7 +204,8 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
                     minLowEnergyDifference = energyDifference;
                 }
             }
-        }
+        } // for all clusters
+        } //for all trackStates
 
         // Apply a final track-cluster association distance cut
         const Cluster *pMatchedCluster = nullptr;
@@ -223,7 +224,6 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
         {
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddTrackClusterAssociation(*this, pTrack, pMatchedCluster));
         }
-        } //for all trackStates
     } //for all tracks
     return STATUS_CODE_SUCCESS;
 }

--- a/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
+++ b/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
@@ -178,7 +178,7 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
                     continue;
 
                 float trackClusterDistance(std::numeric_limits<float>::max());
-                if (STATUS_CODE_SUCCESS != lc_content::ClusterHelper::GetTrackClusterDistance(pTrack, pCluster, m_maxSearchLayer, m_parallelDistanceCut,
+                if (STATUS_CODE_SUCCESS != lc_content::ClusterHelper::GetTrackClusterDistance(&trackState, pCluster, m_maxSearchLayer, m_parallelDistanceCut,
                     m_minTrackClusterCosAngle, trackClusterDistance))
                 {
                     continue;

--- a/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
+++ b/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
@@ -127,84 +127,84 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
         for (auto const& trackState : trackStates)
         {
 
-        const CartesianVector &trackPosition(trackState.GetPosition());
+            const CartesianVector &trackPosition(trackState.GetPosition());
 
 
-        // short circuit this loop with a kd-tree search beforehand
-        // iterating over a std::map is expensive, avoid where possible
-        for (unsigned iPseudoLayer = 0; iPseudoLayer <= m_maxSearchLayer; ++iPseudoLayer)
-        {
-            // save the hash key since we may use it a few times
-            auto hash_key = std::make_pair(pTrack, iPseudoLayer);
-            // see if we have a cached search, otherwise do the search and cache
-            auto cached_result = tracks_to_hits.equal_range(hash_key);
-            if (cached_result.first != tracks_to_hits.end())
+            // short circuit this loop with a kd-tree search beforehand
+            // iterating over a std::map is expensive, avoid where possible
+            for (unsigned iPseudoLayer = 0; iPseudoLayer <= m_maxSearchLayer; ++iPseudoLayer)
             {
-                for (auto iter = cached_result.first; iter != cached_result.second; ++iter )
+                // save the hash key since we may use it a few times
+                auto hash_key = std::make_pair(pTrack, iPseudoLayer);
+                // see if we have a cached search, otherwise do the search and cache
+                auto cached_result = tracks_to_hits.equal_range(hash_key);
+                if (cached_result.first != tracks_to_hits.end())
                 {
-                    // build a list of nearby clusters
-                    nearby_clusters.insert(hits_to_clusters.find(iter->second)->second);
-                }
-            }
-            else
-            {
-                // do search and cache result
-                KDTreeTesseract searchRegionHits = build_4d_kd_search_region(trackPosition, m_parallelDistanceCut, m_parallelDistanceCut, m_parallelDistanceCut, iPseudoLayer);
-                hits_kdtree.search(searchRegionHits, found_hits);
-
-                for (const auto &hit : found_hits)
-                {
-                    auto assc_cluster = hits_to_clusters.find(hit.data);
-                    if (assc_cluster != hits_to_clusters.end())
+                    for (auto iter = cached_result.first; iter != cached_result.second; ++iter )
                     {
-                        // cache all hits that are nearby the track
-                        tracks_to_hits.emplace(hash_key,hit.data);
-                        // add to the list of nearby clusters
-                        nearby_clusters.insert(assc_cluster->second);
+                        // build a list of nearby clusters
+                        nearby_clusters.insert(hits_to_clusters.find(iter->second)->second);
                     }
                 }
-                found_hits.clear();
-            }
-        }
-
-        ClusterList nearbyClusterList(nearby_clusters.begin(), nearby_clusters.end());
-        nearbyClusterList.sort(SortingHelper::SortClustersByNHits);
-        nearby_clusters.clear();
-
-        // Identify the closest cluster and also the closest cluster below a specified hadronic energy threshold
-        for (const Cluster *const pCluster : nearbyClusterList)
-        {
-            if (0 == pCluster->GetNCaloHits())
-                continue;
-
-            float trackClusterDistance(std::numeric_limits<float>::max());
-            if (STATUS_CODE_SUCCESS != lc_content::ClusterHelper::GetTrackClusterDistance(pTrack, pCluster, m_maxSearchLayer, m_parallelDistanceCut,
-                m_minTrackClusterCosAngle, trackClusterDistance))
-            {
-                continue;
-            }
-
-            const float energyDifference(std::fabs(pCluster->GetHadronicEnergy() - pTrack->GetEnergyAtDca()));
-
-            if (pCluster->GetHadronicEnergy() > m_lowEnergyCut)
-            {
-                if ((trackClusterDistance < minDistance) || ((trackClusterDistance == minDistance) && (energyDifference < minEnergyDifference)))
+                else
                 {
-                    minDistance = trackClusterDistance;
-                    pBestCluster = pCluster;
-                    minEnergyDifference = energyDifference;
+                    // do search and cache result
+                    KDTreeTesseract searchRegionHits = build_4d_kd_search_region(trackPosition, m_parallelDistanceCut, m_parallelDistanceCut, m_parallelDistanceCut, iPseudoLayer);
+                    hits_kdtree.search(searchRegionHits, found_hits);
+
+                    for (const auto &hit : found_hits)
+                    {
+                        auto assc_cluster = hits_to_clusters.find(hit.data);
+                        if (assc_cluster != hits_to_clusters.end())
+                        {
+                            // cache all hits that are nearby the track
+                            tracks_to_hits.emplace(hash_key,hit.data);
+                            // add to the list of nearby clusters
+                            nearby_clusters.insert(assc_cluster->second);
+                        }
+                    }
+                    found_hits.clear();
                 }
             }
-            else
+
+            ClusterList nearbyClusterList(nearby_clusters.begin(), nearby_clusters.end());
+            nearbyClusterList.sort(SortingHelper::SortClustersByNHits);
+            nearby_clusters.clear();
+
+            // Identify the closest cluster and also the closest cluster below a specified hadronic energy threshold
+            for (const Cluster *const pCluster : nearbyClusterList)
             {
-                if ((trackClusterDistance < minLowEnergyDistance) || ((trackClusterDistance == minLowEnergyDistance) && (energyDifference < minLowEnergyDifference)))
+                if (0 == pCluster->GetNCaloHits())
+                    continue;
+
+                float trackClusterDistance(std::numeric_limits<float>::max());
+                if (STATUS_CODE_SUCCESS != lc_content::ClusterHelper::GetTrackClusterDistance(pTrack, pCluster, m_maxSearchLayer, m_parallelDistanceCut,
+                    m_minTrackClusterCosAngle, trackClusterDistance))
                 {
-                    minLowEnergyDistance = trackClusterDistance;
-                    pBestLowEnergyCluster = pCluster;
-                    minLowEnergyDifference = energyDifference;
+                    continue;
                 }
-            }
-        } // for all clusters
+
+                const float energyDifference(std::fabs(pCluster->GetHadronicEnergy() - pTrack->GetEnergyAtDca()));
+
+                if (pCluster->GetHadronicEnergy() > m_lowEnergyCut)
+                {
+                    if ((trackClusterDistance < minDistance) || ((trackClusterDistance == minDistance) && (energyDifference < minEnergyDifference)))
+                    {
+                        minDistance = trackClusterDistance;
+                        pBestCluster = pCluster;
+                        minEnergyDifference = energyDifference;
+                    }
+                }
+                else
+                {
+                    if ((trackClusterDistance < minLowEnergyDistance) || ((trackClusterDistance == minLowEnergyDistance) && (energyDifference < minLowEnergyDifference)))
+                    {
+                        minLowEnergyDistance = trackClusterDistance;
+                        pBestLowEnergyCluster = pCluster;
+                        minLowEnergyDifference = energyDifference;
+                    }
+                }
+            } // for all clusters
         } //for all trackStates
 
         // Apply a final track-cluster association distance cut

--- a/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
+++ b/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
@@ -15,6 +15,8 @@
 
 #include "LCUtility/KDTreeLinkerAlgoT.h"
 
+#include "LCObjects/LCTrack.h"
+
 using namespace pandora;
 
 // setup templates for tracking track:pseudolayer pair
@@ -101,9 +103,6 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
         if (!pTrack->GetDaughterList().empty())
             continue;
 
-        const TrackState &trackState(pTrack->GetTrackStateAtCalorimeter());
-        const CartesianVector &trackPosition(trackState.GetPosition());
-
         const Cluster *pBestCluster = nullptr;
         const Cluster *pBestLowEnergyCluster = nullptr;
 
@@ -112,6 +111,24 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
 
         float minEnergyDifference(std::numeric_limits<float>::max());
         float minLowEnergyDifference(std::numeric_limits<float>::max());
+
+        LCTrackStates trackStates;
+        const LCTrack* lcTrack = dynamic_cast<const LCTrack*>(pTrack);
+        if( lcTrack )
+        {
+            trackStates = lcTrack->GetTrackStates();
+        }
+        else
+        {
+            const TrackState &trackState(pTrack->GetTrackStateAtCalorimeter());
+            trackStates.push_back( trackState );
+        }
+
+        for (auto const& trackState : trackStates)
+        {
+
+        const CartesianVector &trackPosition(trackState.GetPosition());
+
 
         // short circuit this loop with a kd-tree search beforehand
         // iterating over a std::map is expensive, avoid where possible
@@ -206,8 +223,8 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
         {
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddTrackClusterAssociation(*this, pTrack, pMatchedCluster));
         }
-    }
-
+        } //for all trackStates
+    } //for all tracks
     return STATUS_CODE_SUCCESS;
 }
 


### PR DESCRIPTION
* Implementd LCTrack class to hold multiple track states at calorimeter
* Adapted TrackClusterAssociationAlgorithm to check different track states
* Adapted ClusterHelper::GetTrackClusterDistance to take a trackState instead of a track so that we can pass the relevant trackState to the function in TrackClusterAssociationAlgorithm, adapt other uses of the function.

For my test sample of 2000 10GeV pions in the relevant direction (34 to 36 degrees polar angle) of the CLIC_o3_v13 detector I find the following number of reconstructed particles

| Particle | Before | After |
| --- | ---: | ---: |
| Neutron |  185 |    9 |
|   Gamma |   90 |   58 |
|   Electron |   29 |   35 |
|   Muon |   20 |   22 |
|  Pi- | 1676 | 1876 |

A lot less neutrons, so cluster are better matched now. I have only compared the first entries from the ReconstructedParticle collection, so the reconstruction performance is probably even better than what is shown in the table. Sometimes particles shower before reaching the calorimeter, so perfect results cannot be expected.
