### PR TITLE
FragmentRemovalHelper: use CartesianVector::GetDistanceSquared

### DIFF
--- a/src/LCHelpers/ClusterHelper.cc
+++ b/src/LCHelpers/ClusterHelper.cc
@@ -94,7 +94,7 @@ float ClusterHelper::GetDistanceToClosestHit(const Cluster *const pClusterI, con
             {
                 for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
                 {
-                    const float distanceSquared((positionVectorI - (*hitIterJ)->GetPositionVector()).GetMagnitudeSquared());
+                    const float distanceSquared(positionVectorI.GetDistanceSquared((*hitIterJ)->GetPositionVector()));
 
                     if (distanceSquared < minDistanceSquared)
                     {
@@ -171,7 +171,7 @@ StatusCode ClusterHelper::GetDistanceToClosestCentroid(const Cluster *const pClu
 
             const CartesianVector centroidJ(pClusterJ->GetCentroid(iterJ->first));
 
-            const float distanceSquared((centroidI - centroidJ).GetMagnitudeSquared());
+            const float distanceSquared(centroidI.GetDistanceSquared(centroidJ));
 
             if (distanceSquared < minDistanceSquared)
             {
@@ -212,7 +212,7 @@ StatusCode ClusterHelper::GetClosestIntraLayerDistance(const Cluster *const pClu
         const CartesianVector centroidI(pClusterI->GetCentroid(pseudoLayer));
         const CartesianVector centroidJ(pClusterJ->GetCentroid(pseudoLayer));
 
-        const float distanceSquared((centroidI - centroidJ).GetMagnitudeSquared());
+        const float distanceSquared(centroidI.GetDistanceSquared(centroidJ));
 
         if (distanceSquared < minDistanceSquared)
         {

--- a/src/LCHelpers/FragmentRemovalHelper.cc
+++ b/src/LCHelpers/FragmentRemovalHelper.cc
@@ -41,7 +41,7 @@ float FragmentRemovalHelper::GetFractionOfCloseHits(const Cluster *const pCluste
             {
                 for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
                 {
-                    const float distanceSquared((positionVectorI - (*hitIterJ)->GetPositionVector()).GetMagnitudeSquared());
+                    const float distanceSquared(positionVectorI.GetDistanceSquared((*hitIterJ)->GetPositionVector()));
 
                     if (distanceSquared < distanceThresholdSquared)
                     {
@@ -281,8 +281,7 @@ StatusCode FragmentRemovalHelper::GetClusterContactDetails(const Cluster *const 
             for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
             {
                 const CartesianVector &positionJ((*hitIterJ)->GetPositionVector());
-                const CartesianVector positionDifference(positionI - positionJ);
-                const float separationSquared(positionDifference.GetMagnitudeSquared());
+                const float separationSquared(positionI.GetDistanceSquared(positionJ));
 
                 if (separationSquared < separationCutSquared)
                 {
@@ -340,7 +339,7 @@ float FragmentRemovalHelper::GetEMEnergyWeightedLayerSeparation(const Cluster *c
                 const CaloHit *const pCaloHitI(*hIterI);
                 const CartesianVector &positionI(pCaloHitI->GetPositionVector());
 
-                const float distanceSquared((positionI - positionJ).GetMagnitudeSquared()); 
+                const float distanceSquared(positionI.GetDistanceSquared(positionJ));
 
                 if (distanceSquared < closestDistanceSquared)
                 {
@@ -443,7 +442,7 @@ void ClusterContact::HitDistanceComparison(const Cluster *const pDaughterCluster
             {
                 for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
                 {
-                    const float distanceSquared((positionVectorI - (*hitIterJ)->GetPositionVector()).GetMagnitudeSquared());
+                    const float distanceSquared(positionVectorI.GetDistanceSquared((*hitIterJ)->GetPositionVector()));
 
                     if (!isCloseHit1 && (distanceSquared < closeHitDistance1Squared))
                         isCloseHit1 = true;


### PR DESCRIPTION
remove overhead of temporary object created in operator-

Using GetDistanceSquared from PandoraPFA/PandoraSDK#7