### PR TITLE
Remove two unused variables to prevent compiler warnings

### DIFF
--- a/src/LCFragmentRemoval/BeamHaloMuonRemovalAlgorithm.cc
+++ b/src/LCFragmentRemoval/BeamHaloMuonRemovalAlgorithm.cc
@@ -142,7 +142,7 @@ bool BeamHaloMuonRemovalAlgorithm::IsBeamHaloMuon(const pandora::Cluster *const 
     const bool isBeamHaloMuonInertia(this->IsBeamHaloMuonInertia(pCluster));
     bool isBeamHaloMuon(isBeamHaloMuonInertia);
 
-    float sumEnergy(0.f), sumEnergyX(0.f), sumEnergyY(0.f), sumEnergyZ(0.f);
+    float sumEnergy(0.f), sumEnergyZ(0.f);
     float xmin(std::numeric_limits<float>::max()), xmax(-std::numeric_limits<float>::max());
     float ymin(std::numeric_limits<float>::max()), ymax(-std::numeric_limits<float>::max());
     float zmin(std::numeric_limits<float>::max()), zmax(-std::numeric_limits<float>::max());
@@ -161,8 +161,6 @@ bool BeamHaloMuonRemovalAlgorithm::IsBeamHaloMuon(const pandora::Cluster *const 
                 const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
 
                 sumEnergy  += energy;
-                sumEnergyX += energy * hitPosition.GetX();
-                sumEnergyY += energy * hitPosition.GetY();
                 sumEnergyZ += energy * hitPosition.GetZ();
 
                 if (hitPosition.GetX() > xmax)


### PR DESCRIPTION
I'm getting the following warnings with Clang 19:

``` c++
/lccontent/src/LCFragmentRemoval/BeamHaloMuonRemovalAlgorithm.cc:145:27: warning: variable 'sumEnergyX' set but not used [-Wunused-but-set-variable]
  145 |     float sumEnergy(0.f), sumEnergyX(0.f), sumEnergyY(0.f), sumEnergyZ(0.f);
      |                           ^
/lccontent/src/LCFragmentRemoval/BeamHaloMuonRemovalAlgorithm.cc:145:44: warning: variable 'sumEnergyY' set but not used [-Wunused-but-set-variable]
  145 |     float sumEnergy(0.f), sumEnergyX(0.f), sumEnergyY(0.f), sumEnergyZ(0.f);
      |                                            ^
```

and it is a bit annoying since `-Werror` is enabled by default, so they promote to errors.