### PR TITLE
Update the CMake configuration to work with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,12 @@ file(GLOB_RECURSE headers ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
 
 add_library(${PROJECT_NAME} SHARED ${LC_CONTENT_SRCS})
 target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS "include" FILES ${headers})
-target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraSDK)
+if(TARGET PandoraPFA::PandoraSDK)
+  target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraSDK)
+else()
+  include_directories(${PandoraSDK_INCLUDE_DIRS})
+  link_libraries(${PandoraSDK_LIBRARIES})
+endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "")
 # Prevent CMake falls back to the latest standard the compiler does support
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
 
 include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_CXX_FLAGS CACHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 if(PANDORA_MONITORING)
   if(TARGET PandoraPFA::PandoraMonitoring)
       target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraMonitoring)
-      target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
   else()
       include_directories(${PandoraMonitoring_INCLUDE_DIRS})
       link_libraries(${PandoraMonitoring_LIBRARIES})
-      target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
   endif()
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
 endif()
 
 option(LCContent_BUILD_DOCS "Build documentation for ${PROJECT_NAME}" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# cmake file for building LCContent
-#-------------------------------------------------------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 2.8.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "LCContent requires an out-of-source build.")
@@ -10,32 +9,19 @@ endif()
 if(NOT LC_CONTENT_LIBRARY_NAME STREQUAL "LCPandoraContent")
     set(LC_CONTENT_LIBRARY_NAME "LCContent")
 endif()
-project(${LC_CONTENT_LIBRARY_NAME})
+project(${LC_CONTENT_LIBRARY_NAME} LANGUAGES CXX)
 
-# project version
 set(${PROJECT_NAME}_VERSION_MAJOR 03)
 set(${PROJECT_NAME}_VERSION_MINOR 01)
 set(${PROJECT_NAME}_VERSION_PATCH 08)
 set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}")
 
-#-------------------------------------------------------------------------------------------------------------------------------------------
-# Dependencies
-include(PandoraCMakeSettings)
+include(GNUInstallDirs)
 
-# Prefer local include directory to any paths to installed header files
-include_directories(include)
-
-find_package(PandoraSDK 03.00.00 REQUIRED)
-include_directories(${PandoraSDK_INCLUDE_DIRS})
-link_libraries(${PandoraSDK_LIBRARIES})
-add_definitions(${PandoraSDK_DEFINITIONS})
+find_package(PandoraSDK 04.00.00 REQUIRED)
 
 if(PANDORA_MONITORING)
     find_package(PandoraMonitoring 03.00.00 REQUIRED)
-    include_directories(${PandoraMonitoring_INCLUDE_DIRS})
-    link_libraries(${PandoraMonitoring_LIBRARIES})
-    add_definitions(${PandoraMonitoring_DEFINITIONS})
-    add_definitions("-DMONITORING")
 endif()
 
 # Set up C++ Standard
@@ -45,8 +31,6 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "")
 # Prevent CMake falls back to the latest standard the compiler does support
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-#-------------------------------------------------------------------------------------------------------------------------------------------
-# Low level settings - compiler etc
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
 
 include(CheckCXXCompilerFlag)
@@ -57,34 +41,39 @@ if(NOT COMPILER_SUPPORTS_CXX_FLAGS)
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} does not support cxx flags ${CMAKE_CXX_FLAGS}")
 endif()
 
-#-------------------------------------------------------------------------------------------------------------------------------------------
-# Build products
 
-# - Collect sources - not ideal because you have to keep running CMake to pick up changes
 file(GLOB_RECURSE LC_CONTENT_SRCS RELATIVE ${PROJECT_SOURCE_DIR} "src/*.cc")
+file(GLOB_RECURSE headers ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
 
-# - Add library and properties
 add_library(${PROJECT_NAME} SHARED ${LC_CONTENT_SRCS})
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} SOVERSION ${${PROJECT_NAME}_SOVERSION})
+target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS "include" FILES ${headers})
+target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraSDK)
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
-# - Optional documents
+if(TARGET PandoraPFA::PandoraMonitoring)
+    target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraMonitoring)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
+else()
+    include_directories(${PandoraMonitoring_INCLUDE_DIRS})
+    link_libraries(${PandoraMonitoring_LIBRARIES})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
+endif()
+
 option(LCContent_BUILD_DOCS "Build documentation for ${PROJECT_NAME}" OFF)
 if(LCContent_BUILD_DOCS)
     add_subdirectory(doc)
 endif()
 
-#-------------------------------------------------------------------------------------------------------------------------------------------
-# Install products
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/LCContent
+  FILE_SET headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT dev
+)
 
-# - library
-install(TARGETS ${PROJECT_NAME} DESTINATION lib COMPONENT Runtime)
+include(cmake/LCContentCreateConfig.cmake)
 
-# - headers
-install(DIRECTORY include/ DESTINATION include COMPONENT Development FILES_MATCHING PATTERN "*.h")
-
-# - support files
-PANDORA_GENERATE_PACKAGE_CONFIGURATION_FILES(${PROJECT_NAME}Config.cmake ${PROJECT_NAME}ConfigVersion.cmake ${PROJECT_NAME}LibDeps.cmake)
-
-#-------------------------------------------------------------------------------------------------------------------------------------------
-# display some variables and write them to cache
-PANDORA_DISPLAY_STD_VARIABLES()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ file(GLOB_RECURSE LC_CONTENT_SRCS RELATIVE ${PROJECT_SOURCE_DIR} "src/*.cc")
 file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
 
 add_library(${PROJECT_NAME} SHARED ${LC_CONTENT_SRCS})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+set(LCContent_LIBRARIES ${PROJECT_NAME}::${PROJECT_NAME})
 target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS "include" FILES ${headers})
 if(TARGET PandoraPFA::PandoraSDK)
   target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraSDK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_
 
 include(GNUInstallDirs)
 
-find_package(PandoraSDK 04.00.00 REQUIRED)
+find_package(PandoraSDK 03.00.00 REQUIRED)
 
 if(PANDORA_MONITORING)
     find_package(PandoraMonitoring 03.00.00 REQUIRED)
@@ -43,7 +43,7 @@ endif()
 
 
 file(GLOB_RECURSE LC_CONTENT_SRCS RELATIVE ${PROJECT_SOURCE_DIR} "src/*.cc")
-file(GLOB_RECURSE headers ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
+file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
 
 add_library(${PROJECT_NAME} SHARED ${LC_CONTENT_SRCS})
 target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS "include" FILES ${headers})
@@ -58,13 +58,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-if(TARGET PandoraPFA::PandoraMonitoring)
-    target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraMonitoring)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
-else()
-    include_directories(${PandoraMonitoring_INCLUDE_DIRS})
-    link_libraries(${PandoraMonitoring_LIBRARIES})
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
+if(PANDORA_MONITORING)
+  if(TARGET PandoraPFA::PandoraMonitoring)
+      target_link_libraries(${PROJECT_NAME} PUBLIC PandoraPFA::PandoraMonitoring)
+      target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
+  else()
+      include_directories(${PandoraMonitoring_INCLUDE_DIRS})
+      link_libraries(${PandoraMonitoring_LIBRARIES})
+      target_compile_definitions(${PROJECT_NAME} PRIVATE -DMONITORING ${PandoraMonitoring_DEFINITIONS})
+  endif()
 endif()
 
 option(LCContent_BUILD_DOCS "Build documentation for ${PROJECT_NAME}" OFF)

--- a/cmake/LCContentConfig.cmake.in
+++ b/cmake/LCContentConfig.cmake.in
@@ -24,9 +24,8 @@
 # @author Jan Engels, Desy
 ##############################################################################
 
-SET( LCContent_ROOT "@CMAKE_INSTALL_PREFIX@" )
+set_and_check(LCContent_ROOT "@CMAKE_INSTALL_PREFIX@")
 SET( LCContent_VERSION "@LCContent_VERSION@" )
-
 
 # ---------- include dirs -----------------------------------------------------
 # do not store find results in cache
@@ -39,27 +38,12 @@ FIND_PATH( LCContent_INCLUDE_DIRS
 	NO_DEFAULT_PATH
 )
 
-
-
-# ---------- libraries --------------------------------------------------------
-INCLUDE( "@PANDORA_CMAKE_MODULES_PATH@/MacroCheckPackageLibs.cmake" )
-
 # only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
 # additional components are set by cmake in variable PKG_FIND_COMPONENTS
 # first argument should be the package name
 CHECK_PACKAGE_LIBS( LCContent LCContent )
 
 
-
-
-# ---------- libraries dependencies -------------------------------------------
-# this sets LCContent_${COMPONENT}_LIB_DEPENDS variables
-INCLUDE( "${LCContent_ROOT}/lib/cmake/LCContentLibDeps.cmake" )
- 
-
-
-
-# ---------- final checking ---------------------------------------------------
 INCLUDE( FindPackageHandleStandardArgs )
 # set LCCONTENTNEW_FOUND to TRUE if all listed variables are TRUE and not empty
 # LCContent_COMPONENT_VARIABLES will be set if FIND_PACKAGE is called with REQUIRED argument

--- a/cmake/LCContentConfig.cmake.in
+++ b/cmake/LCContentConfig.cmake.in
@@ -1,53 +1,28 @@
 ##############################################################################
 # cmake configuration file for LCContent
 #
-# requires:
-#   MacroCheckPackageLibs.cmake for checking package libraries
-#
 # returns following variables:
 #
 #   LCContent_FOUND      : set to TRUE if LCContent found
-#       if FIND_PACKAGE called with REQUIRED and COMPONENTS arguments
-#       LCContent_FOUND is only set to TRUE if ALL components are also found
-#       if REQUIRED is NOT set components may or may not be available
 #
 #   LCContent_ROOT       : path to this LCContent installation
 #   LCContent_VERSION    : package version
 #   LCContent_LIBRARIES  : list of LCContent libraries (NOT including COMPONENTS)
 #   LCContent_INCLUDE_DIRS  : list of paths to be used with INCLUDE_DIRECTORIES
 #   LCContent_LIBRARY_DIRS  : list of paths to be used with LINK_DIRECTORIES
-#   LCContent_COMPONENT_LIBRARIES      : list of LCContent component libraries
-#   LCContent_${COMPONENT}_FOUND       : set to TRUE or FALSE for each library
-#   LCContent_${COMPONENT}_LIBRARY     : path to individual libraries
-#   LCContent_${COMPONENT}_LIB_DEPENDS : individual library dependencies
 #
-# @author Jan Engels, Desy
 ##############################################################################
+@PACKAGE_INIT@
 
 set_and_check(LCContent_ROOT "@CMAKE_INSTALL_PREFIX@")
-SET( LCContent_VERSION "@LCContent_VERSION@" )
+set_and_check(LCContent_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(LCContent_LIBRARY_DIRS "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+set(LCContent_LIBRARIES "@LCContent_LIBRARIES@")
 
-# ---------- include dirs -----------------------------------------------------
-# do not store find results in cache
-SET( LCContent_INCLUDE_DIRS LCContent_INCLUDE_DIRS-NOTFOUND )
-MARK_AS_ADVANCED( LCContent_INCLUDE_DIRS )
+include(CMakeFindDependencyMacro)
+find_dependency(PandoraSDK REQUIRED)
 
-FIND_PATH( LCContent_INCLUDE_DIRS
-	NAMES LCClustering/ClusteringParentAlgorithm.h
-	PATHS ${LCContent_ROOT}/include
-	NO_DEFAULT_PATH
-)
+include("${CMAKE_CURRENT_LIST_DIR}/LCContentTargets.cmake")
 
-# only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
-# additional components are set by cmake in variable PKG_FIND_COMPONENTS
-# first argument should be the package name
-CHECK_PACKAGE_LIBS( LCContent LCContent )
-
-
-INCLUDE( FindPackageHandleStandardArgs )
-# set LCCONTENTNEW_FOUND to TRUE if all listed variables are TRUE and not empty
-# LCContent_COMPONENT_VARIABLES will be set if FIND_PACKAGE is called with REQUIRED argument
-FIND_PACKAGE_HANDLE_STANDARD_ARGS( LCContent DEFAULT_MSG LCContent_ROOT LCContent_INCLUDE_DIRS LCContent_LIBRARIES ${LCContent_COMPONENT_VARIABLES} )
-
-SET( LCContent_FOUND ${LCCONTENTNEW_FOUND} )
+check_required_components(LCContent)
 

--- a/cmake/LCContentCreateConfig.cmake
+++ b/cmake/LCContentCreateConfig.cmake
@@ -1,0 +1,21 @@
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(${PROJECT_BINARY_DIR}/${PROJECT_NAME}Version.cmake
+                                 VERSION ${${PROJECT_NAME}_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+                              ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+                              PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Version.cmake
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} )
+
+install(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
+  FILE "${PROJECT_NAME}Targets.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/"
+)

--- a/cmake/LCContentCreateConfig.cmake
+++ b/cmake/LCContentCreateConfig.cmake
@@ -1,6 +1,6 @@
 include(CMakePackageConfigHelpers)
 
-write_basic_package_version_file(${PROJECT_BINARY_DIR}/${PROJECT_NAME}Version.cmake
+write_basic_package_version_file(${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${${PROJECT_NAME}_VERSION}
                                  COMPATIBILITY AnyNewerVersion)
 
@@ -11,7 +11,7 @@ configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.
                               PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Version.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} )
 
 install(EXPORT ${PROJECT_NAME}Targets


### PR DESCRIPTION
and coming changes to PandoraSDK and PandoraMonitoring. @andychappell has a branch with the same name in both repositories (https://github.com/PandoraPFA/PandoraSDK/compare/master...AndyChappell:PandoraSDK:feature/modern_build and https://github.com/AndyChappell/PandoraMonitoring/tree/feature/modern_build).

These changes can be merged now because they also work with the current version of PandoraSDK, the most important thing being the variable `LCContent_LIBRARIES` that now expands to `LCContent::LCContent`. The new usage should be to link directly to `LCContent::LCContent`, but the usage in `DDMarlinPandora` is to simply call `link_libraries(${LCContent_LIBRARIES})`. This is what I have tested:
- Building against the current `PandoraSDK` with the Key4hep stack, and then building `DDMarlinPandora` on top of this (Alma 9). Also, with and without `PandoraMonitoring`.
- Building locally against the new `PandoraSDK` and `PandoraMonitoring`, using CMake 4.1.1. Then, building `k4GaudiPandora` (which uses `LCContent`), also with and without `PandoraMonitoring`.

Tagging @annazaborowska