### PR TITLE
[WIP] Particle flow reconstruction algorithms for IDEA option2 detector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,15 @@ if(PANDORA_MONITORING)
     find_package(PandoraMonitoring 03.00.00 REQUIRED)
 endif()
 
+# Optional ONNX ML-inference sub-library.  The ONNX-dependent algorithms live in src/MLInference and
+# are built into a SEPARATE library (libLCContentML), so the core LCContent has NO onnxruntime
+# dependency and can be linked without ONNX in the stack.  Enable with -DLCContent_BUILD_ML=ON.
+option(LCContent_BUILD_ML "Build the ONNX ML-inference algorithms into libLCContentML (needs onnxruntime)" OFF)
+
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "")
+# C++17 required by the ONNX Runtime C++ API (also matches the build flags used downstream).
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 
 # Prevent CMake falls back to the latest standard the compiler does support
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -44,6 +50,10 @@ endif()
 
 file(GLOB_RECURSE LC_CONTENT_SRCS RELATIVE ${PROJECT_SOURCE_DIR} "src/*.cc")
 file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "include/*.h")
+
+# Keep the ONNX-dependent MLInference sources/headers out of the core library.
+list(FILTER LC_CONTENT_SRCS EXCLUDE REGEX "^src/MLInference/")
+list(FILTER headers        EXCLUDE REGEX "^include/MLInference/")
 
 add_library(${PROJECT_NAME} SHARED ${LC_CONTENT_SRCS})
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -75,6 +85,40 @@ endif()
 include(CTest)
 if(BUILD_TESTING)
     add_subdirectory(test)
+endif()
+
+# ---- Optional ONNX ML-inference library (libLCContentML) ----
+if(LCContent_BUILD_ML)
+    # New onnxruntime packages ship onnxruntime-Config.cmake (target onnxruntime::onnxruntime);
+    # older ones ship ONNXRuntime.
+    find_package(onnxruntime)
+    if(NOT onnxruntime_FOUND)
+        find_package(ONNXRuntime)
+    endif()
+    if(NOT (onnxruntime_FOUND OR ONNXRuntime_FOUND))
+        message(FATAL_ERROR "LCContent_BUILD_ML=ON but ONNX Runtime was not found.")
+    endif()
+
+    file(GLOB_RECURSE LC_CONTENT_ML_SRCS    RELATIVE ${PROJECT_SOURCE_DIR}        "src/MLInference/*.cc")
+    file(GLOB_RECURSE LC_CONTENT_ML_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "include/MLInference/*.h")
+
+    add_library(LCContentML SHARED ${LC_CONTENT_ML_SRCS})
+    add_library(${PROJECT_NAME}::LCContentML ALIAS LCContentML)
+    target_sources(LCContentML PUBLIC FILE_SET headers TYPE HEADERS BASE_DIRS "include" FILES ${LC_CONTENT_ML_HEADERS})
+    target_link_libraries(LCContentML PUBLIC ${PROJECT_NAME})   # brings PandoraSDK + LCContent includes
+    if(TARGET onnxruntime::onnxruntime)
+        target_link_libraries(LCContentML PUBLIC onnxruntime::onnxruntime)
+    else()
+        target_include_directories(LCContentML PUBLIC ${ONNXRuntime_INCLUDE_DIRS})
+        target_link_libraries(LCContentML PUBLIC ${ONNXRuntime_LIBRARIES})
+    endif()
+
+    install(TARGETS LCContentML
+      EXPORT ${PROJECT_NAME}Targets
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+      FILE_SET headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT dev
+    )
 endif()
 
 option(LCContent_BUILD_DOCS "Build documentation for ${PROJECT_NAME}" OFF)

--- a/cmake/LCContentConfig.cmake.in
+++ b/cmake/LCContentConfig.cmake.in
@@ -22,6 +22,14 @@ set(LCContent_LIBRARIES "@LCContent_LIBRARIES@")
 include(CMakeFindDependencyMacro)
 find_dependency(PandoraSDK REQUIRED)
 
+# ClusterNeutralPidAlgorithm exposes ONNX Runtime in its public ABI, so the
+# onnxruntime imported target must be available to consumers of LCContent.
+# (New packages ship onnxruntime-Config.cmake; older ones ship ONNXRuntime.)
+find_package(onnxruntime QUIET)
+if(NOT onnxruntime_FOUND)
+    find_package(ONNXRuntime QUIET)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/LCContentTargets.cmake")
 
 check_required_components(LCContent)

--- a/include/LCClustering/EcalSeededClusteringAlgorithm.h
+++ b/include/LCClustering/EcalSeededClusteringAlgorithm.h
@@ -1,0 +1,275 @@
+/**
+ *  @file   LCContent/include/LCClustering/EcalSeededClusteringAlgorithm.h
+ *
+ *  @brief  Header for the ECAL-seeded HCAL clustering algorithm.
+ *
+ *  Grows HCAL clusters from ECAL cluster seeds, with BFS topological
+ *  connectivity in (theta, phi) and opening-angle contest resolution on
+ *  contested hits.  Unseeded HCAL clusters (late-developing neutral
+ *  hadrons with no ECAL precursor) are also formed in a second pass.
+ */
+
+#ifndef ECAL_SEEDED_CLUSTERING_ALGORITHM_H
+#define ECAL_SEEDED_CLUSTERING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Pandora/PandoraInternal.h"
+#include "Objects/CartesianVector.h"
+
+#include <functional>
+#include <map>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace lc_content {
+
+class EcalSeededClusteringAlgorithm : public pandora::Algorithm {
+public:
+  // ------------------------------------------------------------------ //
+  //  Factory
+  // ------------------------------------------------------------------ //
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm *CreateAlgorithm() const override {
+      return new EcalSeededClusteringAlgorithm();
+    }
+  };
+
+  EcalSeededClusteringAlgorithm() = default;
+
+private:
+  // ================================================================== //
+  //  Internal data structures
+  // ================================================================== //
+  struct HitCache;
+  typedef std::map<int, std::vector<const HitCache *>> SeedCircleMap;
+
+  /**
+    *  @brief  Compact per-hit cache populated once at startup.
+    *          Storing theta/phi avoids recomputing them in the inner loops.
+    */
+  struct HitCache {
+    const pandora::CaloHit *pHit     = nullptr;
+    pandora::CartesianVector pos{0.f, 0.f, 0.f};
+    float                    energy   = 0.f;  ///< hadronic energy
+    float                    theta    = 0.f;
+    float                    phi      = 0.f;
+    bool                     isCheren = false;
+  };
+
+  /**
+    *  @brief  Common state shared by all cluster types:
+    *          the assigned hit list, the DR-corrected energy, and the
+    *          log-weighted barycenter.  Updated by ComputeClusterState().
+    */
+  struct ClusterState {
+    std::vector<const HitCache *> hits;                       ///< all assigned hits (pool owns storage)
+    std::vector<const HitCache *> vicinity;                   ///< candidate hits for BFS growth
+    float                         energy    = 0.f;            ///< DR-corrected running energy
+    pandora::CartesianVector      barycenter{0.f, 0.f, 0.f}; ///< log-weighted barycenter
+  };
+
+  /**
+    *  @brief  One entry per surviving ECAL cluster seed.
+    */
+  struct SeededCluster : public ClusterState {
+    const pandora::Cluster  *pEcalCluster   = nullptr; ///< target for AddToCluster
+    bool                     isCharged      = false;
+    const pandora::Track    *pBestTrack     = nullptr; ///< highest-p track if charged
+
+    /// Impact point on the HCAL inner surface (mm).
+    pandora::CartesianVector hcalImpactPoint{0.f, 0.f, 0.f};
+    float                    thetaSeed      = 0.f;
+    float                    phiSeed        = 0.f;
+
+    bool                     alive          = true;
+  };
+
+  /**
+    *  @brief  One entry per unseeded HCAL cluster (Phase 5).
+    *          All state is inherited from ClusterState.
+    */
+  struct UnseededCluster : public ClusterState {};
+
+  /// Contest-resolution policy for the shared Grow() engine.
+  enum class GrowStrategy { ResolveByDist, MergeClusters };
+
+  // ================================================================== //
+  //  Phase methods
+  // ================================================================== //
+
+  pandora::StatusCode Run() override;
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+  /**
+    *  @brief  Phase 1a - collect ECAL cluster seeds, filling SeededCluster.
+    *          Photon clusters are skipped.  Charged seeds below
+    *          m_pThres are dropped.
+    */
+  pandora::StatusCode SelectSeeds(const pandora::ClusterList &ecalClusters,
+                                  std::vector<SeededCluster> &seeds) const;
+
+  /**
+    *  @brief  Phase 1b - collect all available HCAL hits into a flat cache.
+    *          ECAL hits are identified by hadronic energy == 0 and skipped.
+    *          Hits below m_hardThreshold are also skipped (scint only).
+    */
+  void BuildHcalPool(const pandora::CaloHitList &allHits,
+                     std::vector<HitCache> &hcalPool) const;
+
+  /**
+    *  @brief  Phase 2a - find the (theta, phi) impact point on the HCAL
+    *          inner surface for each seed.
+    *          Charged seeds: helix extrapolation from track state at ECAL.
+    *          Neutral seeds:  radial projection of ECAL centroid.
+    */
+  pandora::StatusCode ExtrapolateToHcalSurface(SeededCluster &seed) const;
+
+  /**
+    *  @brief  Phase 2b - for each seed, collect the subset of hcalPool
+    *          hits within m_maxSearchDeltaR of the seed impact point.
+    */
+  void BuildVicinities(std::vector<SeededCluster> &seeds,
+                       const std::vector<HitCache> &hcalPool) const;
+
+  /**
+    *  @brief  Phase 3a - for each seed, collect all vicinity hits within
+    *          m_seedCircleRadius of the seed impact point that pass
+    *          m_growThreshold.  Seeds whose scint sum falls below
+    *          m_rhoSeed are killed here.
+    */
+  void FormSeedCircles(
+      std::vector<SeededCluster> &seeds,
+      SeedCircleMap &circles) const;
+
+  /**
+    *  @brief  Phase 3b - resolve hits that appear in more than one seed
+    *          circle using the opening-angle distance against each seed's
+    *          impact point.  Losing seeds keep the remaining
+    *          hits (no second rho_seed check).
+    */
+  void ResolveSeedCircleContests(
+      std::vector<SeededCluster> &seeds,
+      SeedCircleMap &circles) const;
+
+  /**
+    *  @brief  Shared BFS growth engine used by both Phase 4 (seeded) and
+    *          Phase 5 (unseeded).
+    *
+    *  Each ClusterState carries its own vicinity; Grow() only searches within
+    *  that vicinity, avoiding the cost of scanning the full hit pool.
+    *  For MergeClusters, when two clusters are merged their vicinities are
+    *  unioned so the merged cluster can grow into both original regions.
+    *
+    *  ResolveByDist - contested hits go to the cluster with the lowest
+    *                  opening-angle distance; barycenter/energy updated each layer.
+    *  MergeClusters - contested hits cause the two competing clusters to be
+    *                  merged (union-find); the merged cluster accumulates both.
+    *
+    *  @param strategy     Contest-resolution policy.
+    *  @param clusters     Initial clusters; each must have vicinity populated.
+    *  @param assignedSet  Already-assigned hits (blocked from re-assignment); updated in place.
+    *  @return             Grown clusters (folded for MergeClusters).
+    */
+  std::vector<ClusterState> Grow(
+      GrowStrategy strategy,
+      const std::vector<ClusterState> &clusters,
+      pandora::CaloHitSet &assignedSet) const;
+
+  /**
+    *  @brief  Phases 2-4 combined - extrapolate seeds to HCAL surface,
+    *          build vicinities, form and contest seed circles, then BFS-grow.
+    *          On return, assignedSet contains all HCAL hits claimed by seeds.
+    */
+  pandora::StatusCode FormSeededClusters(
+      std::vector<SeededCluster> &seeds,
+      const std::vector<HitCache> &hcalPool,
+      pandora::CaloHitSet &assignedSet) const;
+
+  /**
+    *  @brief  Phase 5 - cluster leftover HCAL hits into unseeded clusters.
+    *          Candidate seeds are hits whose local scint circle energy
+    *          exceeds m_rhoUnseeded.  BFS growth with merge-on-contest
+    *          via union-find.
+    */
+  pandora::StatusCode FormUnseededClusters(
+      std::vector<UnseededCluster> &unseeded,
+      const std::vector<HitCache> &hcalPool,
+      pandora::CaloHitSet &assignedSet) const;
+
+  /**
+    *  @brief  Phase 6 - write results back to Pandora:
+    *          AddToCluster for seeded hits, Cluster::Create for unseeded.
+    */
+  pandora::StatusCode WriteBack(std::vector<SeededCluster> &seeds,
+                                std::vector<UnseededCluster> &unseeded) const;
+
+  // ================================================================== //
+  //  Helper functions
+  // ================================================================== //
+
+  /**
+    *  @brief  Helper: project (theta, phi) direction onto the HCAL inner face.
+    *          Uses barrel vs. endcap geometry based on polar angle.
+    */
+  void ProjectThetaPhiToHcalFace(float theta, float phi,
+                                  pandora::CartesianVector &out) const;
+
+  /// Opening-angle distance: 1 - cos(angle between cluster direction and hit position)
+  float OpeningAngleDist(const pandora::CartesianVector &clusDir,
+                         const pandora::CartesianVector &hitPos) const;
+
+  /// Recompute the DR-corrected energy and log-weighted barycenter of any
+  /// ClusterState (or derived type: SeededCluster, UnseededCluster) from its hits.
+  void ComputeClusterState(ClusterState &cs) const;
+
+  bool IsHcalHit(const pandora::CaloHit *h) const;
+  bool IsCherenkovHit(const pandora::CaloHit *h) const;
+
+  /**
+    *  @brief  Retrieve the HCAL inner surface (barrel inner radius, endcap inner |z|) from the
+    *          Pandora geometry.  Called from ReadSettings: the client creates the geometry before
+    *          PandoraApi::ReadSettings, so the sub-detectors are already registered by then.
+    */
+  pandora::StatusCode ReadHcalGeometry();
+
+  // ================================================================== //
+  //  Configurable parameters
+  // ================================================================== //
+  std::string m_outputClusterListName = "EcalSeededClusters"; ///< Output cluster list name
+  bool  m_useDualReadout    = true;    ///< - use dual-readout info for seed selection and growth
+  /// Take the helix magnetic field at the interaction point instead of at the seed's track state at
+  /// the calorimeter.  Default true: the current field description is exactly zero outside the
+  /// solenoid volume.  Switch off once a realistic (non-uniform) field map is available.
+  bool  m_useBFieldAtIP     = true;
+  float m_pThres            = 1.0f;    ///< GeV - min track p for charged seed
+  float m_hardThreshold     = 0.00f;   ///< GeV - min HCAL hit energy for pool
+  float m_growThreshold     = 0.00f;   ///< GeV - min hit energy that propagates BFS
+
+  // HCAL inner surface: retrieved from the Pandora geometry in ReadSettings (not configurable).
+  float m_hcalSurfaceR      = 0.f;     ///< mm - HCAL barrel inner radius (HCAL_BARREL inner R)
+  float m_hcalSurfaceZHalf  = 0.f;     ///< mm - HCAL endcap inner |z|    (HCAL_ENDCAP inner Z)
+  bool  m_hasHcalEndcap     = true;    ///< false for a barrel-only geometry (no HCAL_ENDCAP registered)
+
+  float m_maxSearchDeltaR   = 0.3f;    ///< rad - per-seed vicinity radius
+  float m_seedCircleRadius  = 50.f;    ///< mm - initial seed circle radius for seeding BFS growth
+  // Strip-anchored seed-circle search windows (FULL widths in rad; the cut is +-0.5x).
+  // Neutral seeds project from the shower-biased ECAL centroid (offset to the true HCAL
+  // energy is larger and phi-dominated), so they use a wider window than charged seeds,
+  // which project from the precise track.
+  float m_stripDThetaCharged = 0.10f;  ///< rad - full theta window, charged seeds
+  float m_stripDPhiCharged   = 0.20f;  ///< rad - full phi   window, charged seeds
+  float m_stripDThetaNeutral = 0.20f;  ///< rad - full theta window, neutral seeds
+  float m_stripDPhiNeutral   = 0.20f;  ///< rad - full phi   window, neutral seeds
+  float m_adjacencyRadius   = 25.f;     ///< mm - BFS adjacency radius
+  float m_rhoSeed           = 0.08f;   ///< GeV - min scint sum in seed circle
+  float m_rhoUnseeded       = 0.08f;   ///< GeV - min scint sum for unseeded candidate
+  float m_w0                = 4.6f;    ///< - log-weight cutoff for barycenter
+  float m_chiHcal           = 0.31f;   ///< - dual-readout chi for HCAL
+  float m_chargedEcalOverPMax = 0.7f;  ///< - skip HCAL growth for a charged seed whose E_DR_ECAL/p exceeds this
+}; // class EcalSeededClusteringAlgorithm
+
+} // namespace lc_content
+
+#endif // ECAL_SEEDED_CLUSTERING_ALGORITHM_H

--- a/include/LCClustering/EcalSeededClusteringAlgorithm.h
+++ b/include/LCClustering/EcalSeededClusteringAlgorithm.h
@@ -12,9 +12,9 @@
 #ifndef ECAL_SEEDED_CLUSTERING_ALGORITHM_H
 #define ECAL_SEEDED_CLUSTERING_ALGORITHM_H 1
 
+#include "Objects/CartesianVector.h"
 #include "Pandora/Algorithm.h"
 #include "Pandora/PandoraInternal.h"
-#include "Objects/CartesianVector.h"
 
 #include <functional>
 #include <map>
@@ -31,9 +31,7 @@ public:
   // ------------------------------------------------------------------ //
   class Factory : public pandora::AlgorithmFactory {
   public:
-    pandora::Algorithm *CreateAlgorithm() const override {
-      return new EcalSeededClusteringAlgorithm();
-    }
+    pandora::Algorithm* CreateAlgorithm() const override { return new EcalSeededClusteringAlgorithm(); }
   };
 
   EcalSeededClusteringAlgorithm() = default;
@@ -43,53 +41,53 @@ private:
   //  Internal data structures
   // ================================================================== //
   struct HitCache;
-  typedef std::map<int, std::vector<const HitCache *>> SeedCircleMap;
+  typedef std::map<int, std::vector<const HitCache*>> SeedCircleMap;
 
   /**
-    *  @brief  Compact per-hit cache populated once at startup.
-    *          Storing theta/phi avoids recomputing them in the inner loops.
-    */
+   *  @brief  Compact per-hit cache populated once at startup.
+   *          Storing theta/phi avoids recomputing them in the inner loops.
+   */
   struct HitCache {
-    const pandora::CaloHit *pHit     = nullptr;
+    const pandora::CaloHit* pHit = nullptr;
     pandora::CartesianVector pos{0.f, 0.f, 0.f};
-    float                    energy   = 0.f;  ///< hadronic energy
-    float                    theta    = 0.f;
-    float                    phi      = 0.f;
-    bool                     isCheren = false;
+    float energy = 0.f; ///< hadronic energy
+    float theta = 0.f;
+    float phi = 0.f;
+    bool isCheren = false;
   };
 
   /**
-    *  @brief  Common state shared by all cluster types:
-    *          the assigned hit list, the DR-corrected energy, and the
-    *          log-weighted barycenter.  Updated by ComputeClusterState().
-    */
+   *  @brief  Common state shared by all cluster types:
+   *          the assigned hit list, the DR-corrected energy, and the
+   *          log-weighted barycenter.  Updated by ComputeClusterState().
+   */
   struct ClusterState {
-    std::vector<const HitCache *> hits;                       ///< all assigned hits (pool owns storage)
-    std::vector<const HitCache *> vicinity;                   ///< candidate hits for BFS growth
-    float                         energy    = 0.f;            ///< DR-corrected running energy
-    pandora::CartesianVector      barycenter{0.f, 0.f, 0.f}; ///< log-weighted barycenter
+    std::vector<const HitCache*> hits;                  ///< all assigned hits (pool owns storage)
+    std::vector<const HitCache*> vicinity;              ///< candidate hits for BFS growth
+    float energy = 0.f;                                 ///< DR-corrected running energy
+    pandora::CartesianVector barycenter{0.f, 0.f, 0.f}; ///< log-weighted barycenter
   };
 
   /**
-    *  @brief  One entry per surviving ECAL cluster seed.
-    */
+   *  @brief  One entry per surviving ECAL cluster seed.
+   */
   struct SeededCluster : public ClusterState {
-    const pandora::Cluster  *pEcalCluster   = nullptr; ///< target for AddToCluster
-    bool                     isCharged      = false;
-    const pandora::Track    *pBestTrack     = nullptr; ///< highest-p track if charged
+    const pandora::Cluster* pEcalCluster = nullptr; ///< target for AddToCluster
+    bool isCharged = false;
+    const pandora::Track* pBestTrack = nullptr; ///< highest-p track if charged
 
     /// Impact point on the HCAL inner surface (mm).
     pandora::CartesianVector hcalImpactPoint{0.f, 0.f, 0.f};
-    float                    thetaSeed      = 0.f;
-    float                    phiSeed        = 0.f;
+    float thetaSeed = 0.f;
+    float phiSeed = 0.f;
 
-    bool                     alive          = true;
+    bool alive = true;
   };
 
   /**
-    *  @brief  One entry per unseeded HCAL cluster (Phase 5).
-    *          All state is inherited from ClusterState.
-    */
+   *  @brief  One entry per unseeded HCAL cluster (Phase 5).
+   *          All state is inherited from ClusterState.
+   */
   struct UnseededCluster : public ClusterState {};
 
   /// Contest-resolution policy for the shared Grow() engine.
@@ -103,171 +101,156 @@ private:
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
   /**
-    *  @brief  Phase 1a - collect ECAL cluster seeds, filling SeededCluster.
-    *          Photon clusters are skipped.  Charged seeds below
-    *          m_pThres are dropped.
-    */
-  pandora::StatusCode SelectSeeds(const pandora::ClusterList &ecalClusters,
-                                  std::vector<SeededCluster> &seeds) const;
+   *  @brief  Phase 1a - collect ECAL cluster seeds, filling SeededCluster.
+   *          Photon clusters are skipped.  Charged seeds below
+   *          m_pThres are dropped.
+   */
+  pandora::StatusCode SelectSeeds(const pandora::ClusterList& ecalClusters, std::vector<SeededCluster>& seeds) const;
 
   /**
-    *  @brief  Phase 1b - collect all available HCAL hits into a flat cache.
-    *          ECAL hits are identified by hadronic energy == 0 and skipped.
-    *          Hits below m_hardThreshold are also skipped (scint only).
-    */
-  void BuildHcalPool(const pandora::CaloHitList &allHits,
-                     std::vector<HitCache> &hcalPool) const;
+   *  @brief  Phase 1b - collect all available HCAL hits into a flat cache.
+   *          ECAL hits are identified by hadronic energy == 0 and skipped.
+   *          Hits below m_hardThreshold are also skipped (scint only).
+   */
+  void BuildHcalPool(const pandora::CaloHitList& allHits, std::vector<HitCache>& hcalPool) const;
 
   /**
-    *  @brief  Phase 2a - find the (theta, phi) impact point on the HCAL
-    *          inner surface for each seed.
-    *          Charged seeds: helix extrapolation from track state at ECAL.
-    *          Neutral seeds:  radial projection of ECAL centroid.
-    */
-  pandora::StatusCode ExtrapolateToHcalSurface(SeededCluster &seed) const;
+   *  @brief  Phase 2a - find the (theta, phi) impact point on the HCAL
+   *          inner surface for each seed.
+   *          Charged seeds: helix extrapolation from track state at ECAL.
+   *          Neutral seeds:  radial projection of ECAL centroid.
+   */
+  pandora::StatusCode ExtrapolateToHcalSurface(SeededCluster& seed) const;
 
   /**
-    *  @brief  Phase 2b - for each seed, collect the subset of hcalPool
-    *          hits within m_maxSearchDeltaR of the seed impact point.
-    */
-  void BuildVicinities(std::vector<SeededCluster> &seeds,
-                       const std::vector<HitCache> &hcalPool) const;
+   *  @brief  Phase 2b - for each seed, collect the subset of hcalPool
+   *          hits within m_maxSearchDeltaR of the seed impact point.
+   */
+  void BuildVicinities(std::vector<SeededCluster>& seeds, const std::vector<HitCache>& hcalPool) const;
 
   /**
-    *  @brief  Phase 3a - for each seed, collect all vicinity hits within
-    *          m_seedCircleRadius of the seed impact point that pass
-    *          m_growThreshold.  Seeds whose scint sum falls below
-    *          m_rhoSeed are killed here.
-    */
-  void FormSeedCircles(
-      std::vector<SeededCluster> &seeds,
-      SeedCircleMap &circles) const;
+   *  @brief  Phase 3a - for each seed, collect all vicinity hits within
+   *          m_seedCircleRadius of the seed impact point that pass
+   *          m_growThreshold.  Seeds whose scint sum falls below
+   *          m_rhoSeed are killed here.
+   */
+  void FormSeedCircles(std::vector<SeededCluster>& seeds, SeedCircleMap& circles) const;
 
   /**
-    *  @brief  Phase 3b - resolve hits that appear in more than one seed
-    *          circle using the opening-angle distance against each seed's
-    *          impact point.  Losing seeds keep the remaining
-    *          hits (no second rho_seed check).
-    */
-  void ResolveSeedCircleContests(
-      std::vector<SeededCluster> &seeds,
-      SeedCircleMap &circles) const;
+   *  @brief  Phase 3b - resolve hits that appear in more than one seed
+   *          circle using the opening-angle distance against each seed's
+   *          impact point.  Losing seeds keep the remaining
+   *          hits (no second rho_seed check).
+   */
+  void ResolveSeedCircleContests(std::vector<SeededCluster>& seeds, SeedCircleMap& circles) const;
 
   /**
-    *  @brief  Shared BFS growth engine used by both Phase 4 (seeded) and
-    *          Phase 5 (unseeded).
-    *
-    *  Each ClusterState carries its own vicinity; Grow() only searches within
-    *  that vicinity, avoiding the cost of scanning the full hit pool.
-    *  For MergeClusters, when two clusters are merged their vicinities are
-    *  unioned so the merged cluster can grow into both original regions.
-    *
-    *  ResolveByDist - contested hits go to the cluster with the lowest
-    *                  opening-angle distance; barycenter/energy updated each layer.
-    *  MergeClusters - contested hits cause the two competing clusters to be
-    *                  merged (union-find); the merged cluster accumulates both.
-    *
-    *  @param strategy     Contest-resolution policy.
-    *  @param clusters     Initial clusters; each must have vicinity populated.
-    *  @param assignedSet  Already-assigned hits (blocked from re-assignment); updated in place.
-    *  @return             Grown clusters (folded for MergeClusters).
-    */
-  std::vector<ClusterState> Grow(
-      GrowStrategy strategy,
-      const std::vector<ClusterState> &clusters,
-      pandora::CaloHitSet &assignedSet) const;
+   *  @brief  Shared BFS growth engine used by both Phase 4 (seeded) and
+   *          Phase 5 (unseeded).
+   *
+   *  Each ClusterState carries its own vicinity; Grow() only searches within
+   *  that vicinity, avoiding the cost of scanning the full hit pool.
+   *  For MergeClusters, when two clusters are merged their vicinities are
+   *  unioned so the merged cluster can grow into both original regions.
+   *
+   *  ResolveByDist - contested hits go to the cluster with the lowest
+   *                  opening-angle distance; barycenter/energy updated each layer.
+   *  MergeClusters - contested hits cause the two competing clusters to be
+   *                  merged (union-find); the merged cluster accumulates both.
+   *
+   *  @param strategy     Contest-resolution policy.
+   *  @param clusters     Initial clusters; each must have vicinity populated.
+   *  @param assignedSet  Already-assigned hits (blocked from re-assignment); updated in place.
+   *  @return             Grown clusters (folded for MergeClusters).
+   */
+  std::vector<ClusterState> Grow(GrowStrategy strategy, const std::vector<ClusterState>& clusters,
+                                 pandora::CaloHitSet& assignedSet) const;
 
   /**
-    *  @brief  Phases 2-4 combined - extrapolate seeds to HCAL surface,
-    *          build vicinities, form and contest seed circles, then BFS-grow.
-    *          On return, assignedSet contains all HCAL hits claimed by seeds.
-    */
-  pandora::StatusCode FormSeededClusters(
-      std::vector<SeededCluster> &seeds,
-      const std::vector<HitCache> &hcalPool,
-      pandora::CaloHitSet &assignedSet) const;
+   *  @brief  Phases 2-4 combined - extrapolate seeds to HCAL surface,
+   *          build vicinities, form and contest seed circles, then BFS-grow.
+   *          On return, assignedSet contains all HCAL hits claimed by seeds.
+   */
+  pandora::StatusCode FormSeededClusters(std::vector<SeededCluster>& seeds, const std::vector<HitCache>& hcalPool,
+                                         pandora::CaloHitSet& assignedSet) const;
 
   /**
-    *  @brief  Phase 5 - cluster leftover HCAL hits into unseeded clusters.
-    *          Candidate seeds are hits whose local scint circle energy
-    *          exceeds m_rhoUnseeded.  BFS growth with merge-on-contest
-    *          via union-find.
-    */
-  pandora::StatusCode FormUnseededClusters(
-      std::vector<UnseededCluster> &unseeded,
-      const std::vector<HitCache> &hcalPool,
-      pandora::CaloHitSet &assignedSet) const;
+   *  @brief  Phase 5 - cluster leftover HCAL hits into unseeded clusters.
+   *          Candidate seeds are hits whose local scint circle energy
+   *          exceeds m_rhoUnseeded.  BFS growth with merge-on-contest
+   *          via union-find.
+   */
+  pandora::StatusCode FormUnseededClusters(std::vector<UnseededCluster>& unseeded,
+                                           const std::vector<HitCache>& hcalPool,
+                                           pandora::CaloHitSet& assignedSet) const;
 
   /**
-    *  @brief  Phase 6 - write results back to Pandora:
-    *          AddToCluster for seeded hits, Cluster::Create for unseeded.
-    */
-  pandora::StatusCode WriteBack(std::vector<SeededCluster> &seeds,
-                                std::vector<UnseededCluster> &unseeded) const;
+   *  @brief  Phase 6 - write results back to Pandora:
+   *          AddToCluster for seeded hits, Cluster::Create for unseeded.
+   */
+  pandora::StatusCode WriteBack(std::vector<SeededCluster>& seeds, std::vector<UnseededCluster>& unseeded) const;
 
   // ================================================================== //
   //  Helper functions
   // ================================================================== //
 
   /**
-    *  @brief  Helper: project (theta, phi) direction onto the HCAL inner face.
-    *          Uses barrel vs. endcap geometry based on polar angle.
-    */
-  void ProjectThetaPhiToHcalFace(float theta, float phi,
-                                  pandora::CartesianVector &out) const;
+   *  @brief  Helper: project (theta, phi) direction onto the HCAL inner face.
+   *          Uses barrel vs. endcap geometry based on polar angle.
+   */
+  void ProjectThetaPhiToHcalFace(float theta, float phi, pandora::CartesianVector& out) const;
 
   /// Opening-angle distance: 1 - cos(angle between cluster direction and hit position)
-  float OpeningAngleDist(const pandora::CartesianVector &clusDir,
-                         const pandora::CartesianVector &hitPos) const;
+  float OpeningAngleDist(const pandora::CartesianVector& clusDir, const pandora::CartesianVector& hitPos) const;
 
   /// Recompute the DR-corrected energy and log-weighted barycenter of any
   /// ClusterState (or derived type: SeededCluster, UnseededCluster) from its hits.
-  void ComputeClusterState(ClusterState &cs) const;
+  void ComputeClusterState(ClusterState& cs) const;
 
-  bool IsHcalHit(const pandora::CaloHit *h) const;
-  bool IsCherenkovHit(const pandora::CaloHit *h) const;
+  bool IsHcalHit(const pandora::CaloHit* h) const;
+  bool IsCherenkovHit(const pandora::CaloHit* h) const;
 
   /**
-    *  @brief  Retrieve the HCAL inner surface (barrel inner radius, endcap inner |z|) from the
-    *          Pandora geometry.  Called from ReadSettings: the client creates the geometry before
-    *          PandoraApi::ReadSettings, so the sub-detectors are already registered by then.
-    */
+   *  @brief  Retrieve the HCAL inner surface (barrel inner radius, endcap inner |z|) from the
+   *          Pandora geometry.  Called from ReadSettings: the client creates the geometry before
+   *          PandoraApi::ReadSettings, so the sub-detectors are already registered by then.
+   */
   pandora::StatusCode ReadHcalGeometry();
 
   // ================================================================== //
   //  Configurable parameters
   // ================================================================== //
   std::string m_outputClusterListName = "EcalSeededClusters"; ///< Output cluster list name
-  bool  m_useDualReadout    = true;    ///< - use dual-readout info for seed selection and growth
+  bool m_useDualReadout = true;                               ///< - use dual-readout info for seed selection and growth
   /// Take the helix magnetic field at the interaction point instead of at the seed's track state at
   /// the calorimeter.  Default true: the current field description is exactly zero outside the
   /// solenoid volume.  Switch off once a realistic (non-uniform) field map is available.
-  bool  m_useBFieldAtIP     = true;
-  float m_pThres            = 1.0f;    ///< GeV - min track p for charged seed
-  float m_hardThreshold     = 0.00f;   ///< GeV - min HCAL hit energy for pool
-  float m_growThreshold     = 0.00f;   ///< GeV - min hit energy that propagates BFS
+  bool m_useBFieldAtIP = true;
+  float m_pThres = 1.0f;         ///< GeV - min track p for charged seed
+  float m_hardThreshold = 0.00f; ///< GeV - min HCAL hit energy for pool
+  float m_growThreshold = 0.00f; ///< GeV - min hit energy that propagates BFS
 
   // HCAL inner surface: retrieved from the Pandora geometry in ReadSettings (not configurable).
-  float m_hcalSurfaceR      = 0.f;     ///< mm - HCAL barrel inner radius (HCAL_BARREL inner R)
-  float m_hcalSurfaceZHalf  = 0.f;     ///< mm - HCAL endcap inner |z|    (HCAL_ENDCAP inner Z)
-  bool  m_hasHcalEndcap     = true;    ///< false for a barrel-only geometry (no HCAL_ENDCAP registered)
+  float m_hcalSurfaceR = 0.f;     ///< mm - HCAL barrel inner radius (HCAL_BARREL inner R)
+  float m_hcalSurfaceZHalf = 0.f; ///< mm - HCAL endcap inner |z|    (HCAL_ENDCAP inner Z)
+  bool m_hasHcalEndcap = true;    ///< false for a barrel-only geometry (no HCAL_ENDCAP registered)
 
-  float m_maxSearchDeltaR   = 0.3f;    ///< rad - per-seed vicinity radius
-  float m_seedCircleRadius  = 50.f;    ///< mm - initial seed circle radius for seeding BFS growth
+  float m_maxSearchDeltaR = 0.3f;  ///< rad - per-seed vicinity radius
+  float m_seedCircleRadius = 50.f; ///< mm - initial seed circle radius for seeding BFS growth
   // Strip-anchored seed-circle search windows (FULL widths in rad; the cut is +-0.5x).
   // Neutral seeds project from the shower-biased ECAL centroid (offset to the true HCAL
   // energy is larger and phi-dominated), so they use a wider window than charged seeds,
   // which project from the precise track.
-  float m_stripDThetaCharged = 0.10f;  ///< rad - full theta window, charged seeds
-  float m_stripDPhiCharged   = 0.20f;  ///< rad - full phi   window, charged seeds
-  float m_stripDThetaNeutral = 0.20f;  ///< rad - full theta window, neutral seeds
-  float m_stripDPhiNeutral   = 0.20f;  ///< rad - full phi   window, neutral seeds
-  float m_adjacencyRadius   = 25.f;     ///< mm - BFS adjacency radius
-  float m_rhoSeed           = 0.08f;   ///< GeV - min scint sum in seed circle
-  float m_rhoUnseeded       = 0.08f;   ///< GeV - min scint sum for unseeded candidate
-  float m_w0                = 4.6f;    ///< - log-weight cutoff for barycenter
-  float m_chiHcal           = 0.31f;   ///< - dual-readout chi for HCAL
-  float m_chargedEcalOverPMax = 0.7f;  ///< - skip HCAL growth for a charged seed whose E_DR_ECAL/p exceeds this
+  float m_stripDThetaCharged = 0.10f; ///< rad - full theta window, charged seeds
+  float m_stripDPhiCharged = 0.20f;   ///< rad - full phi   window, charged seeds
+  float m_stripDThetaNeutral = 0.20f; ///< rad - full theta window, neutral seeds
+  float m_stripDPhiNeutral = 0.20f;   ///< rad - full phi   window, neutral seeds
+  float m_adjacencyRadius = 25.f;     ///< mm - BFS adjacency radius
+  float m_rhoSeed = 0.08f;            ///< GeV - min scint sum in seed circle
+  float m_rhoUnseeded = 0.08f;        ///< GeV - min scint sum for unseeded candidate
+  float m_w0 = 4.6f;                  ///< - log-weight cutoff for barycenter
+  float m_chiHcal = 0.31f;            ///< - dual-readout chi for HCAL
+  float m_chargedEcalOverPMax = 0.7f; ///< - skip HCAL growth for a charged seed whose E_DR_ECAL/p exceeds this
 }; // class EcalSeededClusteringAlgorithm
 
 } // namespace lc_content

--- a/include/LCHelpers/SortingHelper.h
+++ b/include/LCHelpers/SortingHelper.h
@@ -42,6 +42,17 @@ public:
    */
   static bool SortPfosByEnergy(const pandora::ParticleFlowObject* const pLhs,
                                const pandora::ParticleFlowObject* const pRhs);
+
+  /**
+   *  @brief  Sort tracks by ascending distance to cluster centroid at calorimeter
+   * 
+   *  @param  pLhs address of first track
+   *  @param  pRhs address of second track
+   *  @param  pCluster address of cluster to calculate distance to
+   */
+  static bool SortTracksByDistance(const pandora::Track* a,
+                                   const pandora::Track* b,
+                                   const pandora::Cluster* const pCluster);
 };
 
 } // namespace lc_content

--- a/include/LCHelpers/SortingHelper.h
+++ b/include/LCHelpers/SortingHelper.h
@@ -45,13 +45,12 @@ public:
 
   /**
    *  @brief  Sort tracks by ascending distance to cluster centroid at calorimeter
-   * 
+   *
    *  @param  pLhs address of first track
    *  @param  pRhs address of second track
    *  @param  pCluster address of cluster to calculate distance to
    */
-  static bool SortTracksByDistance(const pandora::Track* a,
-                                   const pandora::Track* b,
+  static bool SortTracksByDistance(const pandora::Track* a, const pandora::Track* b,
                                    const pandora::Cluster* const pCluster);
 };
 

--- a/include/LCHelpers/VectorHelper.h
+++ b/include/LCHelpers/VectorHelper.h
@@ -8,9 +8,9 @@ namespace lc_content {
 namespace VectorHelper {
   inline float deltaPhi(float phi1, float phi2) {
     float dphi = phi1 - phi2;
-    
+
     // wrap into [-pi, pi]
-    if (dphi >  static_cast<float>(M_PI))
+    if (dphi > static_cast<float>(M_PI))
       dphi -= 2.f * static_cast<float>(M_PI);
     if (dphi < -static_cast<float>(M_PI))
       dphi += 2.f * static_cast<float>(M_PI);
@@ -21,7 +21,7 @@ namespace VectorHelper {
     const float dt = t1 - t2;
     float dp = deltaPhi(p1, p2);
 
-    return dt*dt + dp*dp;
+    return dt * dt + dp * dp;
   } // AngularDR2
 
   inline float AngularDR(float t1, float p1, float t2, float p2) {

--- a/include/LCHelpers/VectorHelper.h
+++ b/include/LCHelpers/VectorHelper.h
@@ -1,0 +1,33 @@
+#ifndef LC_CONTENT_VECTOR_HELPER_H
+#define LC_CONTENT_VECTOR_HELPER_H 1
+
+#include "Objects/CartesianVector.h"
+#include <cmath>
+
+namespace lc_content {
+namespace VectorHelper {
+  inline float deltaPhi(float phi1, float phi2) {
+    float dphi = phi1 - phi2;
+    
+    // wrap into [-pi, pi]
+    if (dphi >  static_cast<float>(M_PI))
+      dphi -= 2.f * static_cast<float>(M_PI);
+    if (dphi < -static_cast<float>(M_PI))
+      dphi += 2.f * static_cast<float>(M_PI);
+    return dphi;
+  } // deltaPhi
+
+  inline float AngularDR2(float t1, float p1, float t2, float p2) {
+    const float dt = t1 - t2;
+    float dp = deltaPhi(p1, p2);
+
+    return dt*dt + dp*dp;
+  } // AngularDR2
+
+  inline float AngularDR(float t1, float p1, float t2, float p2) {
+    return std::sqrt(AngularDR2(t1, p1, t2, p2));
+  } // AngularDR
+} // namespace VectorHelper
+} // namespace lc_content
+
+#endif // #ifndef LC_CONTENT_VECTOR_HELPER_H

--- a/include/LCParticleId/ForwardPhotonIdAlgorithm.h
+++ b/include/LCParticleId/ForwardPhotonIdAlgorithm.h
@@ -1,0 +1,81 @@
+/**
+ *  @file   LCContent/include/LCParticleId/ForwardPhotonIdAlgorithm.h
+ *
+ *  @brief  Cut-based forward-photon tagging for HCAL-only clusters.
+ *
+ *  A trackless HCAL-only cluster is tagged as a photon (ParticleId = PHOTON) iff
+ *      |eta|        > MinAbsEta         (forward region)      [evaluated first]
+ *      C / S        > MinCS             (Cherenkov-rich, EM-like)
+ *      coreFraction > MinCoreFraction   (laterally compact)
+ *  where C, S are the Cherenkov/scintillation HCAL hit-energy sums, eta is the
+ *  pseudorapidity of the W0 log-weighted centroid, and coreFraction is the
+ *  dual-readout energy within a CoreMm cone (half-angle atan(CoreMm/r_centroid))
+ *  of the centroid divided by the cluster's total dual-readout energy.
+ *
+ *  The |eta| cut is applied first: it is cheap and rejects the bulk of (central)
+ *  clusters before the C/S and core-fraction passes. Clusters that fail any cut
+ *  are left untouched. The tag decouples forward HCAL photons before the
+ *  satellite / neutral-primary steps downstream.
+ */
+#ifndef LC_FORWARD_PHOTON_ID_ALGORITHM_H
+#define LC_FORWARD_PHOTON_ID_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Objects/CartesianVector.h"
+#include "Objects/Cluster.h"
+
+#include <vector>
+
+namespace lc_content {
+
+class ForwardPhotonIdAlgorithm : public pandora::Algorithm {
+public:
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm *CreateAlgorithm() const override {
+      return new ForwardPhotonIdAlgorithm();
+    }
+  };
+
+  ForwardPhotonIdAlgorithm() = default;
+
+  /// A single HCAL hit: position, hadronic-scale energy and Cherenkov flag.
+  /// Public so it can name the helper-method signatures defined out-of-line.
+  struct HcalHit { float x, y, z, e; bool isCher; };
+
+private:
+  pandora::StatusCode Run() override;
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+  /// Collect the cluster's HCAL hits and their total energy. Returns false if
+  /// the cluster carries any ECAL hit (not HCAL-only) or has no HCAL energy.
+  bool CollectHcalHits(const pandora::Cluster *const pCluster,
+                       std::vector<HcalHit> &hits, float &eTotal) const;
+
+  /// W0 log-weighted centroid of the HCAL hits. Returns false if degenerate.
+  bool W0Centroid(const std::vector<HcalHit> &hits, const float eTotal,
+                  pandora::CartesianVector &centroid) const;
+
+  /// Cherenkov-to-scintillation energy ratio C/S; returns a negative sentinel
+  /// when S <= 0 (pure-Cherenkov / empty), which the caller treats as a fail.
+  float CherToScintRatio(const std::vector<HcalHit> &hits) const;
+
+  /// DR core-energy fraction within a CoreMm cone of the centroid direction.
+  float CoreFraction(const std::vector<HcalHit> &hits,
+                     const pandora::CartesianVector &centroid,
+                     const float rCentroid) const;
+
+  /// Dual-readout HCAL energy of a hit set: (S - ChiHcal * C) / (1 - ChiHcal).
+  float DRcorrHcal(const std::vector<HcalHit> &hits) const;
+
+  float m_minCS       = 0.5f;    ///< min Cherenkov/scintillation ratio C/S
+  float m_minAbsEta   = 2.4f;    ///< min |eta| of the cluster centroid
+  float m_coreMm      = 25.f;    ///< core cone lateral size [mm]
+  float m_minCoreFrac = 0.6f;    ///< min DR core-energy fraction
+  float m_w0          = 4.6f;    ///< log-weight offset for the centroid
+  float m_chiHcal     = 0.31f;   ///< HCAL dual-readout chi factor
+};
+
+} // namespace lc_content
+
+#endif // LC_FORWARD_PHOTON_ID_ALGORITHM_H

--- a/include/LCParticleId/ForwardPhotonIdAlgorithm.h
+++ b/include/LCParticleId/ForwardPhotonIdAlgorithm.h
@@ -20,9 +20,9 @@
 #ifndef LC_FORWARD_PHOTON_ID_ALGORITHM_H
 #define LC_FORWARD_PHOTON_ID_ALGORITHM_H 1
 
-#include "Pandora/Algorithm.h"
 #include "Objects/CartesianVector.h"
 #include "Objects/Cluster.h"
+#include "Pandora/Algorithm.h"
 
 #include <vector>
 
@@ -32,16 +32,17 @@ class ForwardPhotonIdAlgorithm : public pandora::Algorithm {
 public:
   class Factory : public pandora::AlgorithmFactory {
   public:
-    pandora::Algorithm *CreateAlgorithm() const override {
-      return new ForwardPhotonIdAlgorithm();
-    }
+    pandora::Algorithm* CreateAlgorithm() const override { return new ForwardPhotonIdAlgorithm(); }
   };
 
   ForwardPhotonIdAlgorithm() = default;
 
   /// A single HCAL hit: position, hadronic-scale energy and Cherenkov flag.
   /// Public so it can name the helper-method signatures defined out-of-line.
-  struct HcalHit { float x, y, z, e; bool isCher; };
+  struct HcalHit {
+    float x, y, z, e;
+    bool isCher;
+  };
 
 private:
   pandora::StatusCode Run() override;
@@ -49,31 +50,28 @@ private:
 
   /// Collect the cluster's HCAL hits and their total energy. Returns false if
   /// the cluster carries any ECAL hit (not HCAL-only) or has no HCAL energy.
-  bool CollectHcalHits(const pandora::Cluster *const pCluster,
-                       std::vector<HcalHit> &hits, float &eTotal) const;
+  bool CollectHcalHits(const pandora::Cluster* const pCluster, std::vector<HcalHit>& hits, float& eTotal) const;
 
   /// W0 log-weighted centroid of the HCAL hits. Returns false if degenerate.
-  bool W0Centroid(const std::vector<HcalHit> &hits, const float eTotal,
-                  pandora::CartesianVector &centroid) const;
+  bool W0Centroid(const std::vector<HcalHit>& hits, const float eTotal, pandora::CartesianVector& centroid) const;
 
   /// Cherenkov-to-scintillation energy ratio C/S; returns a negative sentinel
   /// when S <= 0 (pure-Cherenkov / empty), which the caller treats as a fail.
-  float CherToScintRatio(const std::vector<HcalHit> &hits) const;
+  float CherToScintRatio(const std::vector<HcalHit>& hits) const;
 
   /// DR core-energy fraction within a CoreMm cone of the centroid direction.
-  float CoreFraction(const std::vector<HcalHit> &hits,
-                     const pandora::CartesianVector &centroid,
+  float CoreFraction(const std::vector<HcalHit>& hits, const pandora::CartesianVector& centroid,
                      const float rCentroid) const;
 
   /// Dual-readout HCAL energy of a hit set: (S - ChiHcal * C) / (1 - ChiHcal).
-  float DRcorrHcal(const std::vector<HcalHit> &hits) const;
+  float DRcorrHcal(const std::vector<HcalHit>& hits) const;
 
-  float m_minCS       = 0.5f;    ///< min Cherenkov/scintillation ratio C/S
-  float m_minAbsEta   = 2.4f;    ///< min |eta| of the cluster centroid
-  float m_coreMm      = 25.f;    ///< core cone lateral size [mm]
-  float m_minCoreFrac = 0.6f;    ///< min DR core-energy fraction
-  float m_w0          = 4.6f;    ///< log-weight offset for the centroid
-  float m_chiHcal     = 0.31f;   ///< HCAL dual-readout chi factor
+  float m_minCS = 0.5f;       ///< min Cherenkov/scintillation ratio C/S
+  float m_minAbsEta = 2.4f;   ///< min |eta| of the cluster centroid
+  float m_coreMm = 25.f;      ///< core cone lateral size [mm]
+  float m_minCoreFrac = 0.6f; ///< min DR core-energy fraction
+  float m_w0 = 4.6f;          ///< log-weight offset for the centroid
+  float m_chiHcal = 0.31f;    ///< HCAL dual-readout chi factor
 };
 
 } // namespace lc_content

--- a/include/LCPfoConstruction/IdeaPfoCreationAlgorithm.h
+++ b/include/LCPfoConstruction/IdeaPfoCreationAlgorithm.h
@@ -1,9 +1,9 @@
 #ifndef IdeaPfoCreationAlgorithm_h
 #define IdeaPfoCreationAlgorithm_h 1
 
-#include "Pandora/Algorithm.h"
 #include "Api/PandoraContentApi.h"
 #include "Helpers/XmlHelper.h"
+#include "Pandora/Algorithm.h"
 
 #include "Objects/Cluster.h"
 #include "Objects/Track.h"
@@ -13,7 +13,7 @@ namespace lc_content {
 class IdeaPfoCreationAlgorithm : public pandora::Algorithm {
 public:
   IdeaPfoCreationAlgorithm();
-  ~IdeaPfoCreationAlgorithm()=default;
+  ~IdeaPfoCreationAlgorithm() = default;
 
   class Factory : public pandora::AlgorithmFactory {
   public:
@@ -41,19 +41,19 @@ private:
 
   std::string m_outputPfoListName;
 
-  float m_nSigma         = 2.0f;   ///< Threshold in sigma units for the E_DR/p gate (validated optimum n=2)
-  float m_stochasticHad  = 0.30f;  ///< Hadronic stochastic term
-  float m_constantHad    = 0.01f;  ///< Hadronic constant term
-  float m_stochasticEm   = 0.02f;  ///< EM stochastic term
-  float m_constantEm     = 0.005f; ///< EM constant term
-  float m_ptCut          = 0.6f;
+  float m_nSigma = 2.0f;         ///< Threshold in sigma units for the E_DR/p gate (validated optimum n=2)
+  float m_stochasticHad = 0.30f; ///< Hadronic stochastic term
+  float m_constantHad = 0.01f;   ///< Hadronic constant term
+  float m_stochasticEm = 0.02f;  ///< EM stochastic term
+  float m_constantEm = 0.005f;   ///< EM constant term
+  float m_ptCut = 0.6f;
 
   // ---- regional-excess significance gate for the charged-hadron energy ----
-  float m_coneOpeningAngle = 0.4f;  ///< Regional cone opening angle [rad] for the E/p significance
-  float m_significanceK    = 2.0f;  ///< gate: emit iff  S = (sumEdr-sumP)/(sigma_c(sumEdr)*sumEdr) > k  (validated k=2)
+  float m_coneOpeningAngle = 0.4f; ///< Regional cone opening angle [rad] for the E/p significance
+  float m_significanceK = 2.0f;    ///< gate: emit iff  S = (sumEdr-sumP)/(sigma_c(sumEdr)*sumEdr) > k  (validated k=2)
 
   // non-configurable safe guard
-  float m_sigmaFloor     = 0.001f;  ///< Minimum sigma value
+  float m_sigmaFloor = 0.001f; ///< Minimum sigma value
 
   /// Flat hadronic-response calibration multiplying the E_DR neutral-hadron PFO energy
   /// (default 1.0 = no scaling).  XML "NeutralHadEnergyScale".

--- a/include/LCPfoConstruction/IdeaPfoCreationAlgorithm.h
+++ b/include/LCPfoConstruction/IdeaPfoCreationAlgorithm.h
@@ -1,0 +1,69 @@
+#ifndef IdeaPfoCreationAlgorithm_h
+#define IdeaPfoCreationAlgorithm_h 1
+
+#include "Pandora/Algorithm.h"
+#include "Api/PandoraContentApi.h"
+#include "Helpers/XmlHelper.h"
+
+#include "Objects/Cluster.h"
+#include "Objects/Track.h"
+
+namespace lc_content {
+
+class IdeaPfoCreationAlgorithm : public pandora::Algorithm {
+public:
+  IdeaPfoCreationAlgorithm();
+  ~IdeaPfoCreationAlgorithm()=default;
+
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm* CreateAlgorithm() const;
+  };
+
+private:
+  pandora::StatusCode Run() override;
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+  pandora::StatusCode CreateElectronCandidates(const pandora::ClusterList& aList) const;
+  pandora::StatusCode CreateChargedHadronCandidates(const pandora::ClusterList& aList) const;
+  pandora::StatusCode CreatePhotonCandidates(const pandora::ClusterList& aList) const;
+  pandora::StatusCode CreateNeutralHadronCandidates(const pandora::ClusterList& aList) const;
+  pandora::StatusCode CreatePfoFromTrack(const pandora::TrackList* aList) const;
+
+  pandora::StatusCode GetDualReadoutEnergy(const pandora::Cluster* aClus, float& energy) const;
+  pandora::StatusCode IsEmShower(const pandora::Cluster* aClus, bool& isEmShower) const;
+  float EstimateScintEnergy(const pandora::Cluster* aClus) const;
+
+  const pandora::Track* FindBestAssociatedTrack(const pandora::Cluster* aClus) const;
+
+  /// Calorimeter energy resolution: sigma = stoch/sqrt(p) + const (floored at m_sigmaFloor)
+  float CaloSigma(float p, bool isEm) const;
+
+  std::string m_outputPfoListName;
+
+  float m_nSigma         = 2.0f;   ///< Threshold in sigma units for the E_DR/p gate (validated optimum n=2)
+  float m_stochasticHad  = 0.30f;  ///< Hadronic stochastic term
+  float m_constantHad    = 0.01f;  ///< Hadronic constant term
+  float m_stochasticEm   = 0.02f;  ///< EM stochastic term
+  float m_constantEm     = 0.005f; ///< EM constant term
+  float m_ptCut          = 0.6f;
+
+  // ---- regional-excess significance gate for the charged-hadron energy ----
+  float m_coneOpeningAngle = 0.4f;  ///< Regional cone opening angle [rad] for the E/p significance
+  float m_significanceK    = 2.0f;  ///< gate: emit iff  S = (sumEdr-sumP)/(sigma_c(sumEdr)*sumEdr) > k  (validated k=2)
+
+  // non-configurable safe guard
+  float m_sigmaFloor     = 0.001f;  ///< Minimum sigma value
+
+  /// Flat hadronic-response calibration multiplying the E_DR neutral-hadron PFO energy
+  /// (default 1.0 = no scaling).  XML "NeutralHadEnergyScale".
+  float m_neutralHadScale = 1.0f;
+}; // class IdeaPfoCreationAlgorithm
+
+inline pandora::Algorithm* IdeaPfoCreationAlgorithm::Factory::CreateAlgorithm() const {
+  return new IdeaPfoCreationAlgorithm();
+}
+
+} // namespace lc_content
+
+#endif // #ifndef IdeaPfoCreationAlgorithm_h

--- a/include/LCPlugins/DualReadoutCorrection.h
+++ b/include/LCPlugins/DualReadoutCorrection.h
@@ -1,0 +1,68 @@
+/**
+ *  @file   LCContent/include/LCPlugins/DualReadoutCorrection.h
+ * 
+ *  @brief  Header file for the dual-readout correction plugin algorithm class.
+ * 
+ *  $Log: $
+ */
+#ifndef DUALREADOUT_CORRECTION_H 
+#define DUALREADOUT_CORRECTION_H 1
+
+#include "Plugins/EnergyCorrectionsPlugin.h"
+
+namespace lc_content {
+/**
+  *   @brief  Simple struct to hold dual readout energy information
+  */
+struct DualReadoutEnergy {
+  float ecalS = 0.f;
+  float ecalC = 0.f;
+  float hcalS = 0.f;
+  float hcalC = 0.f;
+  float energyEcalCorrected = 0.f;
+  float energyHcalCorrected = 0.f;
+
+  // for particle ID
+  // Note: SCEP cal doesn't have Cherenkov ch. at depth 0
+  std::map<int, float> ecalS_byDepth;
+  std::map<int, float> ecalC_byDepth;
+};
+
+/**
+  *   @brief  A helper function to apply dual-readout correction to a cluster
+  *           and fill the DualReadoutEnergy struct
+  */
+DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus,
+                                           const float chiEcal, const float chiHcal);
+/**
+ *  @brief  DualReadoutCorrection class. 
+ */
+class DualReadoutCorrection : public pandora::EnergyCorrectionPlugin {
+public:
+  /**
+  *  @brief  Constructor with input parameters
+  *
+  *  @param  parameters the input parameters 
+  */
+  DualReadoutCorrection()=default;
+
+  pandora::StatusCode MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const override;
+
+  /**
+  *  @brief  Access the dual-readout correction factors, so that consumers of the corrected energy
+  *          -- e.g. the error propagation in the edm4hep pfo creator -- use the same chi that was
+  *          applied here instead of keeping a second copy of the values.
+  */
+  float GetChiEcal() const { return m_chiEcal; }
+  float GetChiHcal() const { return m_chiHcal; }
+
+private:
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+  float m_chiEcal = 0.41f; // ECAL dual-readout correction factor
+  float m_chiHcal = 0.31f; // HCAL dual-readout correction factor
+
+}; // class DualReadoutCorrection
+} // namespace lc_content
+
+#endif // #ifndef DUALREADOUT_CORRECTION_H

--- a/include/LCPlugins/DualReadoutCorrection.h
+++ b/include/LCPlugins/DualReadoutCorrection.h
@@ -1,19 +1,19 @@
 /**
  *  @file   LCContent/include/LCPlugins/DualReadoutCorrection.h
- * 
+ *
  *  @brief  Header file for the dual-readout correction plugin algorithm class.
- * 
+ *
  *  $Log: $
  */
-#ifndef DUALREADOUT_CORRECTION_H 
+#ifndef DUALREADOUT_CORRECTION_H
 #define DUALREADOUT_CORRECTION_H 1
 
 #include "Plugins/EnergyCorrectionsPlugin.h"
 
 namespace lc_content {
 /**
-  *   @brief  Simple struct to hold dual readout energy information
-  */
+ *   @brief  Simple struct to hold dual readout energy information
+ */
 struct DualReadoutEnergy {
   float ecalS = 0.f;
   float ecalC = 0.f;
@@ -29,30 +29,31 @@ struct DualReadoutEnergy {
 };
 
 /**
-  *   @brief  A helper function to apply dual-readout correction to a cluster
-  *           and fill the DualReadoutEnergy struct
-  */
-DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus,
-                                           const float chiEcal, const float chiHcal);
+ *   @brief  A helper function to apply dual-readout correction to a cluster
+ *           and fill the DualReadoutEnergy struct
+ */
+DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus, const float chiEcal,
+                                           const float chiHcal);
 /**
- *  @brief  DualReadoutCorrection class. 
+ *  @brief  DualReadoutCorrection class.
  */
 class DualReadoutCorrection : public pandora::EnergyCorrectionPlugin {
 public:
   /**
-  *  @brief  Constructor with input parameters
-  *
-  *  @param  parameters the input parameters 
-  */
-  DualReadoutCorrection()=default;
+   *  @brief  Constructor with input parameters
+   *
+   *  @param  parameters the input parameters
+   */
+  DualReadoutCorrection() = default;
 
-  pandora::StatusCode MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const override;
+  pandora::StatusCode MakeEnergyCorrections(const pandora::Cluster* const pCluster,
+                                            float& correctedEnergy) const override;
 
   /**
-  *  @brief  Access the dual-readout correction factors, so that consumers of the corrected energy
-  *          -- e.g. the error propagation in the edm4hep pfo creator -- use the same chi that was
-  *          applied here instead of keeping a second copy of the values.
-  */
+   *  @brief  Access the dual-readout correction factors, so that consumers of the corrected energy
+   *          -- e.g. the error propagation in the edm4hep pfo creator -- use the same chi that was
+   *          applied here instead of keeping a second copy of the values.
+   */
   float GetChiEcal() const { return m_chiEcal; }
   float GetChiHcal() const { return m_chiHcal; }
 

--- a/include/LCUtility/IsolatedHitPreparationAlgorithm.h
+++ b/include/LCUtility/IsolatedHitPreparationAlgorithm.h
@@ -1,0 +1,95 @@
+#ifndef IsolatedHitPreparationAlgorithm_h
+#define IsolatedHitPreparationAlgorithm_h 1
+
+#include "Pandora/Algorithm.h"
+#include "Helpers/XmlHelper.h"
+
+#include "Api/PandoraContentApi.h"
+#include "Objects/CaloHit.h"
+#include "Objects/Cluster.h"
+
+#include <unordered_set>
+
+namespace lc_content {
+
+class IsolatedHitPreparationAlgorithm : public pandora::Algorithm {
+public:
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm* CreateAlgorithm() const;
+  };
+
+  IsolatedHitPreparationAlgorithm()=default;
+
+private:
+  pandora::StatusCode Run() override {
+    // retrieve clusters
+    const pandora::ClusterList *pClusterList = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
+    // retrieve calo hits
+    const pandora::CaloHitList *pCaloHitList = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
+
+    // collect hits that are not clustered
+    std::unordered_set<const pandora::CaloHit*> clusteredHits;
+    for (const auto* pCluster : *pClusterList) {
+      pandora::CaloHitList clusterHits;
+      pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHits);
+      for (const auto* pHit : clusterHits)
+        clusteredHits.insert(pHit);
+    } // loop over clusters
+
+    // set hits that are not clustered as isolated
+    for (const auto* pHit : *pCaloHitList) {
+      if (clusteredHits.count(pHit) == 0) {
+        if (m_excludeEcal && pHit->GetElectromagneticEnergy() > 0.f)
+          continue; // configured to exclude ECAL hits from isolated hit flagging
+        if (m_excludeHcal && pHit->GetHadronicEnergy() > 0.f)
+          continue; // configured to exclude HCAL hits from isolated hit flagging
+
+        // energy zero-suppression: drop isolated-hit candidates below the configured cut.
+        // The cut is a direct energy (GeV) threshold -- set it to the energy that corresponds
+        // to your desired photon count.  A separate cherenkov cut is applied only when
+        // CherEnergyThreshold > 0; otherwise the (scintillation) cut applies to all.
+        const bool isCher = pHit->GetHitType() == pandora::DRC_CHEREN;
+        const float threshold = (isCher && m_cherEnergyThreshold > 0.f) ? m_cherEnergyThreshold
+                                                                        : m_scintEnergyThreshold;
+        if (pHit->GetInputEnergy() <= threshold)
+          continue; // sub-threshold -> never flagged isolated -> not merged / not regressed
+
+        PandoraContentApi::CaloHit::Metadata metadata;
+        metadata.m_isIsolated = true;
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::CaloHit::AlterMetadata(*this, pHit, metadata));
+      }
+    } // loop over calo hits
+
+    return pandora::STATUS_CODE_SUCCESS;
+  } // Run
+
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override {
+    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+        pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeEcalHits", m_excludeEcal));
+    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+        pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeHcalHits", m_excludeHcal));
+    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+        pandora::XmlHelper::ReadValue(xmlHandle, "ScintEnergyThreshold", m_scintEnergyThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+        pandora::XmlHelper::ReadValue(xmlHandle, "CherEnergyThreshold", m_cherEnergyThreshold));
+
+    return pandora::STATUS_CODE_SUCCESS;
+  } // ReadSettings
+
+  bool  m_excludeEcal = false;          ///< whether to exclude ECAL hits from isolated hit flagging (default: false)
+  bool  m_excludeHcal = false;          ///< whether to exclude HCAL hits from isolated hit flagging (default: false)
+  float m_scintEnergyThreshold = 0.f;   ///< energy cut (GeV) applied to scint hits (and cher if cher cut = 0)
+  float m_cherEnergyThreshold  = 0.f;   ///< if > 0, energy cut (GeV) applied to cherenkov hits instead
+};
+
+inline pandora::Algorithm* IsolatedHitPreparationAlgorithm::Factory::CreateAlgorithm() const {
+  return new IsolatedHitPreparationAlgorithm();
+}
+
+} // namespace lc_content
+
+#endif // IsolatedHitPreparationAlgorithm_h

--- a/include/LCUtility/IsolatedHitPreparationAlgorithm.h
+++ b/include/LCUtility/IsolatedHitPreparationAlgorithm.h
@@ -1,8 +1,8 @@
 #ifndef IsolatedHitPreparationAlgorithm_h
 #define IsolatedHitPreparationAlgorithm_h 1
 
-#include "Pandora/Algorithm.h"
 #include "Helpers/XmlHelper.h"
+#include "Pandora/Algorithm.h"
 
 #include "Api/PandoraContentApi.h"
 #include "Objects/CaloHit.h"
@@ -19,15 +19,15 @@ public:
     pandora::Algorithm* CreateAlgorithm() const;
   };
 
-  IsolatedHitPreparationAlgorithm()=default;
+  IsolatedHitPreparationAlgorithm() = default;
 
 private:
   pandora::StatusCode Run() override {
     // retrieve clusters
-    const pandora::ClusterList *pClusterList = nullptr;
+    const pandora::ClusterList* pClusterList = nullptr;
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
     // retrieve calo hits
-    const pandora::CaloHitList *pCaloHitList = nullptr;
+    const pandora::CaloHitList* pCaloHitList = nullptr;
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
 
     // collect hits that are not clustered
@@ -52,15 +52,15 @@ private:
         // to your desired photon count.  A separate cherenkov cut is applied only when
         // CherEnergyThreshold > 0; otherwise the (scintillation) cut applies to all.
         const bool isCher = pHit->GetHitType() == pandora::DRC_CHEREN;
-        const float threshold = (isCher && m_cherEnergyThreshold > 0.f) ? m_cherEnergyThreshold
-                                                                        : m_scintEnergyThreshold;
+        const float threshold =
+            (isCher && m_cherEnergyThreshold > 0.f) ? m_cherEnergyThreshold : m_scintEnergyThreshold;
         if (pHit->GetInputEnergy() <= threshold)
           continue; // sub-threshold -> never flagged isolated -> not merged / not regressed
 
         PandoraContentApi::CaloHit::Metadata metadata;
         metadata.m_isIsolated = true;
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-            PandoraContentApi::CaloHit::AlterMetadata(*this, pHit, metadata));
+                                 PandoraContentApi::CaloHit::AlterMetadata(*this, pHit, metadata));
       }
     } // loop over calo hits
 
@@ -69,21 +69,23 @@ private:
 
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override {
     PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-        pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeEcalHits", m_excludeEcal));
+                                    pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeEcalHits", m_excludeEcal));
     PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-        pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeHcalHits", m_excludeHcal));
-    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                    pandora::XmlHelper::ReadValue(xmlHandle, "ExcludeHcalHits", m_excludeHcal));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
         pandora::XmlHelper::ReadValue(xmlHandle, "ScintEnergyThreshold", m_scintEnergyThreshold));
-    PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
         pandora::XmlHelper::ReadValue(xmlHandle, "CherEnergyThreshold", m_cherEnergyThreshold));
 
     return pandora::STATUS_CODE_SUCCESS;
   } // ReadSettings
 
-  bool  m_excludeEcal = false;          ///< whether to exclude ECAL hits from isolated hit flagging (default: false)
-  bool  m_excludeHcal = false;          ///< whether to exclude HCAL hits from isolated hit flagging (default: false)
-  float m_scintEnergyThreshold = 0.f;   ///< energy cut (GeV) applied to scint hits (and cher if cher cut = 0)
-  float m_cherEnergyThreshold  = 0.f;   ///< if > 0, energy cut (GeV) applied to cherenkov hits instead
+  bool m_excludeEcal = false;         ///< whether to exclude ECAL hits from isolated hit flagging (default: false)
+  bool m_excludeHcal = false;         ///< whether to exclude HCAL hits from isolated hit flagging (default: false)
+  float m_scintEnergyThreshold = 0.f; ///< energy cut (GeV) applied to scint hits (and cher if cher cut = 0)
+  float m_cherEnergyThreshold = 0.f;  ///< if > 0, energy cut (GeV) applied to cherenkov hits instead
 };
 
 inline pandora::Algorithm* IsolatedHitPreparationAlgorithm::Factory::CreateAlgorithm() const {

--- a/include/MLInference/ClusterNeutralPidAlgorithm.h
+++ b/include/MLInference/ClusterNeutralPidAlgorithm.h
@@ -1,0 +1,110 @@
+/**
+ *  @file   LCContent/include/MLInference/ClusterNeutralPidAlgorithm.h
+ *
+ *  @brief  Header file for the neutral-PID (sat/NH/photon) ONNX tagging algorithm.
+ *
+ *  Port of k4RecCalorimeter ClusterNeutralPidOnnx into a Pandora algorithm.  Runs a
+ *  ParT multi-class model returning a softmax over {satellite, neutral-hadron, photon}
+ *  for every cluster in the current list and writes the verdict as the cluster
+ *  ParticleId:  photon -> pandora::PHOTON, NH -> pandora::K_LONG, satellite ->
+ *  pandora::UNKNOWN_PARTICLE_TYPE.  Charged identification is left to the downstream
+ *  track-cluster matching (the model was trained with charged primaries excluded).
+ *
+ *  Token construction matches photonId_hitcollect_multi.py / ClusterNeutralPidOnnx:
+ *    own_ECAL  (<=BudgetOwnEcal)   cluster's own ECAL hits            type_id=0
+ *    other_ECAL(<=BudgetOtherEcal) ECAL hits in cone, not in cluster  type_id=1
+ *    HCAL      (<=BudgetHcal)      HCAL hits in cone                  type_id=2
+ *    track     (<=BudgetTrack)     track impacts in cone             type_id=3
+ *  Per-token features (5): (dTheta, dPhi, depth|FA, ln E|ln|p|, is_cher|FA), where
+ *  FA = FEATURE_ABSENT (-1) marks a feature that does not apply to that token type and
+ *  must stay -1 to match the trained model.
+ */
+#ifndef LC_CLUSTER_NEUTRAL_PID_ALGORITHM_H
+#define LC_CLUSTER_NEUTRAL_PID_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Objects/CaloHit.h"
+
+#include "MLInference/OnnxSession.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace lc_content {
+
+/**
+ *  @brief  ClusterNeutralPidAlgorithm class
+ */
+class ClusterNeutralPidAlgorithm : public pandora::Algorithm {
+public:
+  /**
+   *  @brief  Factory class for instantiating algorithm
+   */
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm *CreateAlgorithm() const;
+  };
+
+  ClusterNeutralPidAlgorithm();
+  ~ClusterNeutralPidAlgorithm();
+
+private:
+  pandora::StatusCode Run() override;
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+  // ---- token feature constants (must match the trained model) ----
+  static constexpr float FEATURE_ABSENT = -1.f;  ///< sentinel: feature N/A for this token type
+  static constexpr int   N_FEAT    = 5;
+  static constexpr int   N_CLASSES = 3;
+  static constexpr int   TID_OWN   = 0;
+  static constexpr int   TID_OTHER = 1;
+  static constexpr int   TID_HCAL  = 2;
+  static constexpr int   TID_TRACK = 3;
+
+  /**
+   *  @brief  Pre-decoded calorimeter hit (Pandora-side)
+   */
+  struct Hit {
+    float    ux, uy, uz;   ///< unit direction
+    float    th, ph;       ///< polar / azimuth
+    float    e;            ///< input (digi-channel) energy = CaloHit::GetInputEnergy()
+    float    depthFeat;    ///< ECAL: CaloHit::GetLayer(); HCAL token slot uses FEATURE_ABSENT
+    float    cherFeat;     ///< 1 if HitType==DRC_CHEREN, else 0
+    bool     isEcal;       ///< electromagnetic (ECAL) hit (GetHadronicEnergy() <= 0)
+    const pandora::CaloHit *pCaloHit;
+  };
+
+  struct TrackImpact {
+    float ux, uy, uz;
+    float th, ph;
+    float p;
+  };
+
+  pandora::StatusCode LoadModel();
+  int                 Decide(float s0, float s1, float s2) const;  ///< raw model scores [sat, NH, photon]
+
+  // ---- configuration (XML) ----
+  std::string m_modelPath;       ///< path to the ParT multi-class ONNX file
+  float       m_w0;              ///< W0 for the log-weighted cluster barycenter (matches k4)
+  float       m_coneLateralMm;   ///< lateral cone [mm]: half-angle = atan(d / r_cluster)
+  int         m_budgetOwnEcal;   ///< max own-ECAL tokens per cluster
+  int         m_budgetOtherEcal; ///< max other-ECAL tokens per cluster
+  int         m_budgetHcal;      ///< max HCAL tokens per cluster
+  int         m_budgetTrack;     ///< max track tokens per cluster
+  float       m_photonThreshold; ///< if <0: argmax(3); else photon if sm[photon] > threshold
+  int         m_maxTokens;       ///< sum of budgets
+
+  // ---- ONNX session ----
+  std::unique_ptr<OnnxSession> m_session;   ///< ONNX session; null / invalid until the model is loaded
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline pandora::Algorithm *ClusterNeutralPidAlgorithm::Factory::CreateAlgorithm() const {
+  return new ClusterNeutralPidAlgorithm();
+}
+
+} // namespace lc_content
+
+#endif // #ifndef LC_CLUSTER_NEUTRAL_PID_ALGORITHM_H

--- a/include/MLInference/ClusterNeutralPidAlgorithm.h
+++ b/include/MLInference/ClusterNeutralPidAlgorithm.h
@@ -22,8 +22,8 @@
 #ifndef LC_CLUSTER_NEUTRAL_PID_ALGORITHM_H
 #define LC_CLUSTER_NEUTRAL_PID_ALGORITHM_H 1
 
-#include "Pandora/Algorithm.h"
 #include "Objects/CaloHit.h"
+#include "Pandora/Algorithm.h"
 
 #include "MLInference/OnnxSession.h"
 
@@ -43,7 +43,7 @@ public:
    */
   class Factory : public pandora::AlgorithmFactory {
   public:
-    pandora::Algorithm *CreateAlgorithm() const;
+    pandora::Algorithm* CreateAlgorithm() const;
   };
 
   ClusterNeutralPidAlgorithm();
@@ -54,25 +54,25 @@ private:
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
   // ---- token feature constants (must match the trained model) ----
-  static constexpr float FEATURE_ABSENT = -1.f;  ///< sentinel: feature N/A for this token type
-  static constexpr int   N_FEAT    = 5;
-  static constexpr int   N_CLASSES = 3;
-  static constexpr int   TID_OWN   = 0;
-  static constexpr int   TID_OTHER = 1;
-  static constexpr int   TID_HCAL  = 2;
-  static constexpr int   TID_TRACK = 3;
+  static constexpr float FEATURE_ABSENT = -1.f; ///< sentinel: feature N/A for this token type
+  static constexpr int N_FEAT = 5;
+  static constexpr int N_CLASSES = 3;
+  static constexpr int TID_OWN = 0;
+  static constexpr int TID_OTHER = 1;
+  static constexpr int TID_HCAL = 2;
+  static constexpr int TID_TRACK = 3;
 
   /**
    *  @brief  Pre-decoded calorimeter hit (Pandora-side)
    */
   struct Hit {
-    float    ux, uy, uz;   ///< unit direction
-    float    th, ph;       ///< polar / azimuth
-    float    e;            ///< input (digi-channel) energy = CaloHit::GetInputEnergy()
-    float    depthFeat;    ///< ECAL: CaloHit::GetLayer(); HCAL token slot uses FEATURE_ABSENT
-    float    cherFeat;     ///< 1 if HitType==DRC_CHEREN, else 0
-    bool     isEcal;       ///< electromagnetic (ECAL) hit (GetHadronicEnergy() <= 0)
-    const pandora::CaloHit *pCaloHit;
+    float ux, uy, uz; ///< unit direction
+    float th, ph;     ///< polar / azimuth
+    float e;          ///< input (digi-channel) energy = CaloHit::GetInputEnergy()
+    float depthFeat;  ///< ECAL: CaloHit::GetLayer(); HCAL token slot uses FEATURE_ABSENT
+    float cherFeat;   ///< 1 if HitType==DRC_CHEREN, else 0
+    bool isEcal;      ///< electromagnetic (ECAL) hit (GetHadronicEnergy() <= 0)
+    const pandora::CaloHit* pCaloHit;
   };
 
   struct TrackImpact {
@@ -82,26 +82,26 @@ private:
   };
 
   pandora::StatusCode LoadModel();
-  int                 Decide(float s0, float s1, float s2) const;  ///< raw model scores [sat, NH, photon]
+  int Decide(float s0, float s1, float s2) const; ///< raw model scores [sat, NH, photon]
 
   // ---- configuration (XML) ----
-  std::string m_modelPath;       ///< path to the ParT multi-class ONNX file
-  float       m_w0;              ///< W0 for the log-weighted cluster barycenter (matches k4)
-  float       m_coneLateralMm;   ///< lateral cone [mm]: half-angle = atan(d / r_cluster)
-  int         m_budgetOwnEcal;   ///< max own-ECAL tokens per cluster
-  int         m_budgetOtherEcal; ///< max other-ECAL tokens per cluster
-  int         m_budgetHcal;      ///< max HCAL tokens per cluster
-  int         m_budgetTrack;     ///< max track tokens per cluster
-  float       m_photonThreshold; ///< if <0: argmax(3); else photon if sm[photon] > threshold
-  int         m_maxTokens;       ///< sum of budgets
+  std::string m_modelPath; ///< path to the ParT multi-class ONNX file
+  float m_w0;              ///< W0 for the log-weighted cluster barycenter (matches k4)
+  float m_coneLateralMm;   ///< lateral cone [mm]: half-angle = atan(d / r_cluster)
+  int m_budgetOwnEcal;     ///< max own-ECAL tokens per cluster
+  int m_budgetOtherEcal;   ///< max other-ECAL tokens per cluster
+  int m_budgetHcal;        ///< max HCAL tokens per cluster
+  int m_budgetTrack;       ///< max track tokens per cluster
+  float m_photonThreshold; ///< if <0: argmax(3); else photon if sm[photon] > threshold
+  int m_maxTokens;         ///< sum of budgets
 
   // ---- ONNX session ----
-  std::unique_ptr<OnnxSession> m_session;   ///< ONNX session; null / invalid until the model is loaded
+  std::unique_ptr<OnnxSession> m_session; ///< ONNX session; null / invalid until the model is loaded
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::Algorithm *ClusterNeutralPidAlgorithm::Factory::CreateAlgorithm() const {
+inline pandora::Algorithm* ClusterNeutralPidAlgorithm::Factory::CreateAlgorithm() const {
   return new ClusterNeutralPidAlgorithm();
 }
 

--- a/include/MLInference/OnnxSession.h
+++ b/include/MLInference/OnnxSession.h
@@ -27,12 +27,12 @@ public:
    *  @param  modelPath        path to the .onnx model file
    *  @param  intraOpThreads   ONNX Runtime intra-op thread count (default 1)
    */
-  explicit OnnxSession(const std::string &modelPath, int intraOpThreads = 1);
+  explicit OnnxSession(const std::string& modelPath, int intraOpThreads = 1);
 
   ~OnnxSession();
 
-  OnnxSession(const OnnxSession &) = delete;
-  OnnxSession &operator=(const OnnxSession &) = delete;
+  OnnxSession(const OnnxSession&) = delete;
+  OnnxSession& operator=(const OnnxSession&) = delete;
 
   /**
    *  @brief  Whether the model loaded successfully.
@@ -41,8 +41,8 @@ public:
 
   std::size_t InputCount() const;
   std::size_t OutputCount() const;
-  const std::vector<std::string> &InputNames() const;
-  const std::vector<std::string> &OutputNames() const;
+  const std::vector<std::string>& InputNames() const;
+  const std::vector<std::string>& OutputNames() const;
 
   /**
    *  @brief  The model's declared shape for input `index` (e.g. to validate a fixed token dimension).
@@ -59,7 +59,7 @@ public:
 
     std::vector<std::int64_t> shape;
     Type type = Type::Float;
-    const void *data = nullptr;
+    const void* data = nullptr;
   };
 
   /**
@@ -70,7 +70,7 @@ public:
    *
    *  @return one float vector per model output; empty on failure (which is logged)
    */
-  std::vector<std::vector<float>> Run(const std::vector<Input> &inputs) const;
+  std::vector<std::vector<float>> Run(const std::vector<Input>& inputs) const;
 
 private:
   struct Impl; ///< holds the Ort::Env / Session / MemoryInfo / I/O names

--- a/include/MLInference/OnnxSession.h
+++ b/include/MLInference/OnnxSession.h
@@ -1,0 +1,82 @@
+/**
+ *  @file   LCContent/include/MLInference/OnnxSession.h
+ *
+ *  @brief  Thin PIMPL wrapper around an ONNX Runtime session.  The onnxruntime dependency is
+ *          confined to OnnxSession.cc, so the ML-inference algorithms (and their headers) never
+ *          include any onnxruntime header.
+ */
+#ifndef LC_MLINFERENCE_ONNX_SESSION_H
+#define LC_MLINFERENCE_ONNX_SESSION_H 1
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace lc_content {
+
+/**
+ *  @brief  OnnxSession class: owns an ONNX Runtime session and runs inference on flat buffers.
+ */
+class OnnxSession {
+public:
+  /**
+   *  @brief  Load the model at modelPath.  On failure the session is left INVALID (see IsValid());
+   *          the constructor never throws.
+   *
+   *  @param  modelPath        path to the .onnx model file
+   *  @param  intraOpThreads   ONNX Runtime intra-op thread count (default 1)
+   */
+  explicit OnnxSession(const std::string &modelPath, int intraOpThreads = 1);
+
+  ~OnnxSession();
+
+  OnnxSession(const OnnxSession &) = delete;
+  OnnxSession &operator=(const OnnxSession &) = delete;
+
+  /**
+   *  @brief  Whether the model loaded successfully.
+   */
+  bool IsValid() const;
+
+  std::size_t InputCount() const;
+  std::size_t OutputCount() const;
+  const std::vector<std::string> &InputNames() const;
+  const std::vector<std::string> &OutputNames() const;
+
+  /**
+   *  @brief  The model's declared shape for input `index` (e.g. to validate a fixed token dimension).
+   *          Empty if the session is invalid or the index is out of range.
+   */
+  std::vector<std::int64_t> InputShape(std::size_t index) const;
+
+  /**
+   *  @brief  One model input: its row-major shape, element type, and a pointer to caller-owned data
+   *          which must stay valid for the duration of the Run() call.
+   */
+  struct Input {
+    enum class Type { Float, Int64, Bool };
+
+    std::vector<std::int64_t> shape;
+    Type type = Type::Float;
+    const void *data = nullptr;
+  };
+
+  /**
+   *  @brief  Run inference.  Inputs are positional (inputs[i] feeds InputNames()[i]).  Each model
+   *          output is returned flattened to float (these models' outputs are float).
+   *
+   *  @param  inputs  the model inputs, in the model's input order
+   *
+   *  @return one float vector per model output; empty on failure (which is logged)
+   */
+  std::vector<std::vector<float>> Run(const std::vector<Input> &inputs) const;
+
+private:
+  struct Impl; ///< holds the Ort::Env / Session / MemoryInfo / I/O names
+  std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace lc_content
+
+#endif // #ifndef LC_MLINFERENCE_ONNX_SESSION_H

--- a/include/MLInference/SatelliteAssignmentOnnxAlgorithm.h
+++ b/include/MLInference/SatelliteAssignmentOnnxAlgorithm.h
@@ -19,9 +19,9 @@
 #ifndef LC_SATELLITE_ASSIGNMENT_ONNX_ALGORITHM_H
 #define LC_SATELLITE_ASSIGNMENT_ONNX_ALGORITHM_H 1
 
-#include "Pandora/Algorithm.h"
-#include "Objects/Cluster.h"
 #include "Objects/CartesianVector.h"
+#include "Objects/Cluster.h"
+#include "Pandora/Algorithm.h"
 
 #include "MLInference/OnnxSession.h"
 
@@ -38,7 +38,7 @@ class SatelliteAssignmentOnnxAlgorithm : public pandora::Algorithm {
 public:
   class Factory : public pandora::AlgorithmFactory {
   public:
-    pandora::Algorithm *CreateAlgorithm() const override { return new SatelliteAssignmentOnnxAlgorithm(); }
+    pandora::Algorithm* CreateAlgorithm() const override { return new SatelliteAssignmentOnnxAlgorithm(); }
   };
 
   SatelliteAssignmentOnnxAlgorithm() = default;
@@ -49,85 +49,84 @@ private:
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
   // ---- token layout (must match the model's training tokenisation) ----
-  static constexpr int N_FEAT  = 6;          ///< [dTheta, dPhi, depth, ln(E|p), isCher, isEcal]
+  static constexpr int N_FEAT = 6; ///< [dTheta, dPhi, depth, ln(E|p), isCher, isEcal]
   enum TokenType { TYPE_OWN = 0, TYPE_OTHER = 1, TYPE_TRACK = 2 };
-  static constexpr float SENT = -1.0f;       ///< sentinel for absent depth/cher/ecal (track tokens)
+  static constexpr float SENT = -1.0f; ///< sentinel for absent depth/cher/ecal (track tokens)
 
   /// One calorimeter hit's per-token features (position reduced to angles).
   struct Hit {
     float theta = 0.f, phi = 0.f, energy = 0.f, depth = SENT;
-    bool  isEcal = false, isCher = false;
+    bool isEcal = false, isCher = false;
   };
 
   /// Per-cluster cache: hits, energy-weighted centroid direction, and (if any) the track state.
   struct ClusterInfo {
-    const pandora::Cluster  *pCluster = nullptr;
+    const pandora::Cluster* pCluster = nullptr;
     pandora::CartesianVector centroidDir{0.f, 0.f, 0.f};
-    std::vector<Hit>         hits;
-    bool  hasTrack = false;                  ///< has a track reaching the calorimeter (any p) -> charged primary
-    float trkTheta = 0.f, trkPhi = 0.f, trkP = 0.f;   ///< track state AT CALORIMETER (no projection)
+    std::vector<Hit> hits;
+    bool hasTrack = false;                          ///< has a track reaching the calorimeter (any p) -> charged primary
+    float trkTheta = 0.f, trkPhi = 0.f, trkP = 0.f; ///< track state AT CALORIMETER (no projection)
   };
 
   /// One in-cone neighbour's model affinity to the candidate, tagged tracked/neutral.
   struct NeighbourAff {
-    const pandora::Cluster *pCluster = nullptr;
-    bool  hasTrack = false;                   ///< neighbour is a charged primary (has a calo-reaching track)
-    float affinity = 0.f;                     ///< sigmoid(logit), P(same particle as candidate), in [0,1]
+    const pandora::Cluster* pCluster = nullptr;
+    bool hasTrack = false; ///< neighbour is a charged primary (has a calo-reaching track)
+    float affinity = 0.f;  ///< sigmoid(logit), P(same particle as candidate), in [0,1]
   };
 
   void LoadModel();
-  static Hit ExtractHit(const pandora::CaloHit *pHit);
+  static Hit ExtractHit(const pandora::CaloHit* pHit);
 
   /// Fill hits + energy-weighted centroid + best track state at the calo. False if no usable hits.
-  bool BuildInfo(const pandora::Cluster *pCluster, ClusterInfo &info) const;
+  bool BuildInfo(const pandora::Cluster* pCluster, ClusterInfo& info) const;
 
   /// Snapshot the current cluster list into per-cluster caches (hits, energy-weighted centroid, best
   /// track state).  Clusters with no usable hits are skipped.
-  pandora::StatusCode BuildClusterCache(std::vector<ClusterInfo> &clusters) const;
+  pandora::StatusCode BuildClusterCache(std::vector<ClusterInfo>& clusters) const;
 
   /// Select the merge candidates = available, trackless, non-photon clusters (as indices into
   /// `clusters`).  Tracked clusters are charged primaries (targets, never candidates); photons are
   /// left to the upstream photon logic.
-  void CollectCandidates(const std::vector<ClusterInfo> &clusters, std::vector<int> &candidates) const;
+  void CollectCandidates(const std::vector<ClusterInfo>& clusters, std::vector<int>& candidates) const;
 
   /// Build the candidate's token set (own + in-cone neighbour hits + track tokens), run the ONNX model
   /// ONCE, and return one affinity per in-cone neighbour cluster.  False on failure / no neighbour.
-  bool ComputeNeighbourAffinities(const std::vector<ClusterInfo> &clusters, int candIndex,
-                                  std::vector<NeighbourAff> &out) const;
+  bool ComputeNeighbourAffinities(const std::vector<ClusterInfo>& clusters, int candIndex,
+                                  std::vector<NeighbourAff>& out) const;
 
   /// Pass 1 (frozen == deployed): plan each candidate's merge into its highest-affinity TRACKED
   /// neighbour if that affinity exceeds AffinityThreshold.  Fills chargedMerges (child -> parent).
-  void PlanChargedMerges(const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
-                         const std::map<int, std::vector<NeighbourAff>> &affinities,
-                         std::map<const pandora::Cluster *, const pandora::Cluster *> &chargedMerges) const;
+  void PlanChargedMerges(const std::vector<ClusterInfo>& clusters, const std::vector<int>& candidates,
+                         const std::map<int, std::vector<NeighbourAff>>& affinities,
+                         std::map<const pandora::Cluster*, const pandora::Cluster*>& chargedMerges) const;
 
   /// Pass 2 (opt-in): union-find over neutral<->neutral affinities exceeding NeutralAffinityThreshold,
   /// among the clusters that stayed neutral (charged assignment frozen).  Fills neutralGroups; each
   /// group's representative (the biggest cluster, merged INTO) is placed first.
-  void PlanNeutralGroups(const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
-                         const std::map<int, std::vector<NeighbourAff>> &affinities,
-                         const std::set<const pandora::Cluster *> &becameCharged,
-                         std::vector<std::vector<const pandora::Cluster *>> &neutralGroups) const;
+  void PlanNeutralGroups(const std::vector<ClusterInfo>& clusters, const std::vector<int>& candidates,
+                         const std::map<int, std::vector<NeighbourAff>>& affinities,
+                         const std::set<const pandora::Cluster*>& becameCharged,
+                         std::vector<std::vector<const pandora::Cluster*>>& neutralGroups) const;
 
   /// Execute the planned charged merges (candidate cluster -> its tracked parent).
-  pandora::StatusCode ApplyChargedMerges(
-      const std::map<const pandora::Cluster *, const pandora::Cluster *> &merges) const;
+  pandora::StatusCode
+  ApplyChargedMerges(const std::map<const pandora::Cluster*, const pandora::Cluster*>& merges) const;
 
   /// Execute the planned neutral groups (merge every other member of each component into its first =
   /// representative cluster).
-  pandora::StatusCode ApplyNeutralGroups(
-      const std::vector<std::vector<const pandora::Cluster *>> &groups) const;
+  pandora::StatusCode ApplyNeutralGroups(const std::vector<std::vector<const pandora::Cluster*>>& groups) const;
 
-  std::string m_modelPath;                   ///< ONNX model path (required)
-  float m_affinityThreshold = 0.50f;         ///< merge to charged if best tracked affinity > this
-  bool  m_groupNeutral = true;               ///< 2nd pass: union-find neutral<->neutral grouping (on by default)
-  float m_neutralAffinityThreshold = 0.72f;  ///< union two neutral clusters if their affinity > this
-  float m_coneHalfAngle     = 0.4f;          ///< rad, token/neighbour cone half-angle
-  float m_coneCos           = std::cos(0.4f);
-  int   m_budgetOwn         = 512;           ///< top-K own hits by energy
-  int   m_budgetNbr         = 64;            ///< top-K hits per neighbour cluster by energy (no cap on #clusters)
+  std::string m_modelPath;                  ///< ONNX model path (required)
+  float m_affinityThreshold = 0.50f;        ///< merge to charged if best tracked affinity > this
+  bool m_groupNeutral = true;               ///< 2nd pass: union-find neutral<->neutral grouping (on by default)
+  float m_neutralAffinityThreshold = 0.72f; ///< union two neutral clusters if their affinity > this
+  float m_coneHalfAngle = 0.4f;             ///< rad, token/neighbour cone half-angle
+  float m_coneCos = std::cos(0.4f);
+  int m_budgetOwn = 512; ///< top-K own hits by energy
+  int m_budgetNbr = 64;  ///< top-K hits per neighbour cluster by energy (no cap on #clusters)
 
-  std::unique_ptr<OnnxSession> m_session;    ///< ONNX session; null / invalid until the model is loaded
+  std::unique_ptr<OnnxSession> m_session; ///< ONNX session; null / invalid until the model is loaded
 };
 
 } // namespace lc_content

--- a/include/MLInference/SatelliteAssignmentOnnxAlgorithm.h
+++ b/include/MLInference/SatelliteAssignmentOnnxAlgorithm.h
@@ -1,0 +1,135 @@
+/**
+ *  @file   LCContent/include/MLInference/SatelliteAssignmentOnnxAlgorithm.h
+ *
+ *  @brief  Cluster-grouping satellite assignment via an ONNX pairwise-affinity model (SPLIT policy).
+ *
+ *  For each trackless, non-photon cluster (a satellite / neutral candidate) the ONNX model scores,
+ *  for every in-cone neighbour cluster, the affinity P(same particle as the candidate).  SPLIT
+ *  policy: the candidate is merged into the TRACKED cluster with the highest affinity if that
+ *  affinity exceeds AffinityThreshold; otherwise it is kept as a neutral PFO.  There is NO
+ *  neutral-neutral grouping and NO transitive union -- a candidate's charged/neutral fate depends
+ *  only on its own DIRECT affinity to a tracked cluster (cascade-free).  Two tracked clusters are
+ *  never merged (each track = one charged particle).  Isolated-hit merging is a downstream step.
+ *
+ *  The ONNX graph takes the candidate's token set -- own hits + in-cone neighbour hits + track
+ *  tokens, tagged by type {own,other,track} and a pfo-index {0=candidate, 1..K=neighbours} -- and
+ *  returns one affinity logit per neighbour pfo.  The pfo dimension is dynamic, so the number of
+ *  neighbour clusters is never capped.
+ */
+#ifndef LC_SATELLITE_ASSIGNMENT_ONNX_ALGORITHM_H
+#define LC_SATELLITE_ASSIGNMENT_ONNX_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Objects/Cluster.h"
+#include "Objects/CartesianVector.h"
+
+#include "MLInference/OnnxSession.h"
+
+#include <cmath>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace lc_content {
+
+class SatelliteAssignmentOnnxAlgorithm : public pandora::Algorithm {
+public:
+  class Factory : public pandora::AlgorithmFactory {
+  public:
+    pandora::Algorithm *CreateAlgorithm() const override { return new SatelliteAssignmentOnnxAlgorithm(); }
+  };
+
+  SatelliteAssignmentOnnxAlgorithm() = default;
+  ~SatelliteAssignmentOnnxAlgorithm() override;
+
+private:
+  pandora::StatusCode Run() override;
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
+
+  // ---- token layout (must match the model's training tokenisation) ----
+  static constexpr int N_FEAT  = 6;          ///< [dTheta, dPhi, depth, ln(E|p), isCher, isEcal]
+  enum TokenType { TYPE_OWN = 0, TYPE_OTHER = 1, TYPE_TRACK = 2 };
+  static constexpr float SENT = -1.0f;       ///< sentinel for absent depth/cher/ecal (track tokens)
+
+  /// One calorimeter hit's per-token features (position reduced to angles).
+  struct Hit {
+    float theta = 0.f, phi = 0.f, energy = 0.f, depth = SENT;
+    bool  isEcal = false, isCher = false;
+  };
+
+  /// Per-cluster cache: hits, energy-weighted centroid direction, and (if any) the track state.
+  struct ClusterInfo {
+    const pandora::Cluster  *pCluster = nullptr;
+    pandora::CartesianVector centroidDir{0.f, 0.f, 0.f};
+    std::vector<Hit>         hits;
+    bool  hasTrack = false;                  ///< has a track reaching the calorimeter (any p) -> charged primary
+    float trkTheta = 0.f, trkPhi = 0.f, trkP = 0.f;   ///< track state AT CALORIMETER (no projection)
+  };
+
+  /// One in-cone neighbour's model affinity to the candidate, tagged tracked/neutral.
+  struct NeighbourAff {
+    const pandora::Cluster *pCluster = nullptr;
+    bool  hasTrack = false;                   ///< neighbour is a charged primary (has a calo-reaching track)
+    float affinity = 0.f;                     ///< sigmoid(logit), P(same particle as candidate), in [0,1]
+  };
+
+  void LoadModel();
+  static Hit ExtractHit(const pandora::CaloHit *pHit);
+
+  /// Fill hits + energy-weighted centroid + best track state at the calo. False if no usable hits.
+  bool BuildInfo(const pandora::Cluster *pCluster, ClusterInfo &info) const;
+
+  /// Snapshot the current cluster list into per-cluster caches (hits, energy-weighted centroid, best
+  /// track state).  Clusters with no usable hits are skipped.
+  pandora::StatusCode BuildClusterCache(std::vector<ClusterInfo> &clusters) const;
+
+  /// Select the merge candidates = available, trackless, non-photon clusters (as indices into
+  /// `clusters`).  Tracked clusters are charged primaries (targets, never candidates); photons are
+  /// left to the upstream photon logic.
+  void CollectCandidates(const std::vector<ClusterInfo> &clusters, std::vector<int> &candidates) const;
+
+  /// Build the candidate's token set (own + in-cone neighbour hits + track tokens), run the ONNX model
+  /// ONCE, and return one affinity per in-cone neighbour cluster.  False on failure / no neighbour.
+  bool ComputeNeighbourAffinities(const std::vector<ClusterInfo> &clusters, int candIndex,
+                                  std::vector<NeighbourAff> &out) const;
+
+  /// Pass 1 (frozen == deployed): plan each candidate's merge into its highest-affinity TRACKED
+  /// neighbour if that affinity exceeds AffinityThreshold.  Fills chargedMerges (child -> parent).
+  void PlanChargedMerges(const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
+                         const std::map<int, std::vector<NeighbourAff>> &affinities,
+                         std::map<const pandora::Cluster *, const pandora::Cluster *> &chargedMerges) const;
+
+  /// Pass 2 (opt-in): union-find over neutral<->neutral affinities exceeding NeutralAffinityThreshold,
+  /// among the clusters that stayed neutral (charged assignment frozen).  Fills neutralGroups; each
+  /// group's representative (the biggest cluster, merged INTO) is placed first.
+  void PlanNeutralGroups(const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
+                         const std::map<int, std::vector<NeighbourAff>> &affinities,
+                         const std::set<const pandora::Cluster *> &becameCharged,
+                         std::vector<std::vector<const pandora::Cluster *>> &neutralGroups) const;
+
+  /// Execute the planned charged merges (candidate cluster -> its tracked parent).
+  pandora::StatusCode ApplyChargedMerges(
+      const std::map<const pandora::Cluster *, const pandora::Cluster *> &merges) const;
+
+  /// Execute the planned neutral groups (merge every other member of each component into its first =
+  /// representative cluster).
+  pandora::StatusCode ApplyNeutralGroups(
+      const std::vector<std::vector<const pandora::Cluster *>> &groups) const;
+
+  std::string m_modelPath;                   ///< ONNX model path (required)
+  float m_affinityThreshold = 0.50f;         ///< merge to charged if best tracked affinity > this
+  bool  m_groupNeutral = true;               ///< 2nd pass: union-find neutral<->neutral grouping (on by default)
+  float m_neutralAffinityThreshold = 0.72f;  ///< union two neutral clusters if their affinity > this
+  float m_coneHalfAngle     = 0.4f;          ///< rad, token/neighbour cone half-angle
+  float m_coneCos           = std::cos(0.4f);
+  int   m_budgetOwn         = 512;           ///< top-K own hits by energy
+  int   m_budgetNbr         = 64;            ///< top-K hits per neighbour cluster by energy (no cap on #clusters)
+
+  std::unique_ptr<OnnxSession> m_session;    ///< ONNX session; null / invalid until the model is loaded
+};
+
+} // namespace lc_content
+
+#endif // LC_SATELLITE_ASSIGNMENT_ONNX_ALGORITHM_H

--- a/src/LCClustering/EcalSeededClusteringAlgorithm.cc
+++ b/src/LCClustering/EcalSeededClusteringAlgorithm.cc
@@ -16,12 +16,12 @@
  *   6   WriteBack      - AddToCluster / Cluster::Create
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "Api/PandoraContentApi.h"
-#include "Objects/Track.h"
-#include "Objects/Cluster.h"
 #include "Objects/CaloHit.h"
+#include "Objects/Cluster.h"
 #include "Objects/Helix.h"
+#include "Objects/Track.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 #include "LCClustering/EcalSeededClusteringAlgorithm.h"
 #include "LCHelpers/VectorHelper.h"
@@ -45,17 +45,16 @@ namespace lc_content {
 pandora::StatusCode EcalSeededClusteringAlgorithm::Run() {
   // ---- get Pandora input lists ----
   // assume all existing clusters are ECAL clusters
-  const pandora::ClusterList *pEcalClusterList  = nullptr;
-  const pandora::CaloHitList *pCurrentCaloHitList = nullptr;
+  const pandora::ClusterList* pEcalClusterList = nullptr;
+  const pandora::CaloHitList* pCurrentCaloHitList = nullptr;
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::GetCurrentList(*this, pEcalClusterList));
+                           PandoraContentApi::GetCurrentList(*this, pEcalClusterList));
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::GetCurrentList(*this, pCurrentCaloHitList));
+                           PandoraContentApi::GetCurrentList(*this, pCurrentCaloHitList));
 
   // ---- Phase 1a: ECAL seed selection ----
   std::vector<SeededCluster> seeds;
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      SelectSeeds(*pEcalClusterList, seeds));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, SelectSeeds(*pEcalClusterList, seeds));
 
   // ---- Phase 1b: HCAL hit pool ----
   std::vector<HitCache> hcalPool; // this is the owner of the cached hit info
@@ -68,19 +67,16 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::Run() {
   pandora::CaloHitSet assignedSet;
 
   if (!seeds.empty()) {
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-        FormSeededClusters(seeds, hcalPool, assignedSet));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, FormSeededClusters(seeds, hcalPool, assignedSet));
   }
 
   // ---- Phase 5: unseeded clusters from leftover hits ----
   // Runs regardless of whether any ECAL seeds were present.
   std::vector<UnseededCluster> unseeded;
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      FormUnseededClusters(unseeded, hcalPool, assignedSet));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, FormUnseededClusters(unseeded, hcalPool, assignedSet));
 
   // ---- Phase 6: write back to Pandora ----
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      WriteBack(seeds, unseeded));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, WriteBack(seeds, unseeded));
 
   return pandora::STATUS_CODE_SUCCESS;
 }
@@ -89,17 +85,17 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::Run() {
 //  Phase 1a - SelectSeeds
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::ClusterList &ecalClusters,
-                                                               std::vector<SeededCluster> &seeds) const {
+pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::ClusterList& ecalClusters,
+                                                               std::vector<SeededCluster>& seeds) const {
   // loop over ECAL clusters and filter out
-  for (const pandora::Cluster *const pClus : ecalClusters) {
+  for (const pandora::Cluster* const pClus : ecalClusters) {
     if (!pClus->IsAvailable())
       continue;
 
     SeededCluster s;
     s.pEcalCluster = pClus;
 
-    const auto &tracks = pClus->GetAssociatedTrackList();
+    const auto& tracks = pClus->GetAssociatedTrackList();
     if (tracks.empty()) {
       // Only grow HCAL behind neutral clusters tagged as neutral hadrons by the
       // external PID (cluster particleId == K_LONG, set upstream from the edm4hep
@@ -108,13 +104,13 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::Cl
       if (pClus->GetParticleId() != pandora::K_LONG)
         continue;
 
-      s.isCharged  = false;
+      s.isCharged = false;
       s.pBestTrack = nullptr;
     } else {
       // Charged cluster: take the highest-momentum associated track
-      const pandora::Track *bestTrack = nullptr;
+      const pandora::Track* bestTrack = nullptr;
       float bestP = 0.f;
-      for (const auto *t : tracks) {
+      for (const auto* t : tracks) {
         const float p = t->GetMomentumAtDca().GetMagnitude();
 
         if (p > bestP) {
@@ -134,14 +130,13 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::Cl
       // the cluster is ECAL-only and corrHad is just E_DR_ECAL.
       float eEcal = 0.f;
       if (m_useDualReadout) {
-        const pandora::EnergyCorrections *const pCorr =
-            PandoraContentApi::GetPlugins(*this)->GetEnergyCorrections();
+        const pandora::EnergyCorrections* const pCorr = PandoraContentApi::GetPlugins(*this)->GetEnergyCorrections();
         if (pCorr == nullptr)
           return pandora::STATUS_CODE_FAILURE;
 
         float corrEm = 0.f, corrHad = 0.f;
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-            pCorr->MakeEnergyCorrections(pClus, corrEm, corrHad));
+                                 pCorr->MakeEnergyCorrections(pClus, corrEm, corrHad));
         eEcal = corrHad;
       } else {
         eEcal = pClus->GetElectromagneticEnergy();
@@ -150,7 +145,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::Cl
       if (eEcal >= m_chargedEcalOverPMax * bestP)
         continue;
 
-      s.isCharged  = true;
+      s.isCharged = true;
       s.pBestTrack = bestTrack;
     }
 
@@ -164,20 +159,20 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::Cl
 //  Phase 1b - BuildHcalPool
 // ====================================================================== //
 
-void EcalSeededClusteringAlgorithm::BuildHcalPool(const pandora::CaloHitList &allHits,
-                                                  std::vector<HitCache> &hcalPool) const {
+void EcalSeededClusteringAlgorithm::BuildHcalPool(const pandora::CaloHitList& allHits,
+                                                  std::vector<HitCache>& hcalPool) const {
   // loop over all hits and cache HCAL hits above threshold
   hcalPool.reserve(allHits.size());
-  for (const pandora::CaloHit *const h : allHits) {
+  for (const pandora::CaloHit* const h : allHits) {
     if (h->GetHadronicEnergy() <= 0.f)
       continue; // skip ECAL
     if (h->GetHadronicEnergy() < m_hardThreshold)
       continue;
 
     HitCache hc;
-    hc.pHit  = h;
-    hc.pos   = h->GetPositionVector();
-    hc.energy  = h->GetHadronicEnergy();
+    hc.pHit = h;
+    hc.pos = h->GetPositionVector();
+    hc.energy = h->GetHadronicEnergy();
 
     float r;
     hc.pos.GetSphericalCoordinates(r, hc.phi, hc.theta);
@@ -190,7 +185,7 @@ void EcalSeededClusteringAlgorithm::BuildHcalPool(const pandora::CaloHitList &al
 //  Phase 2a - ExtrapolateToHcalSurface
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(SeededCluster &s) const {
+pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(SeededCluster& s) const {
   pandora::CartesianVector impact(0.f, 0.f, 0.f);
 
   if (s.isCharged && s.pBestTrack != nullptr) {
@@ -199,9 +194,9 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
     //  pandora::Helix::GetPointOnCircle  (barrel)  and
     //  pandora::Helix::GetPointInZ       (endcap).
     // ---------------------------------------------------------------- //
-    const pandora::TrackState& tsAtCalo = s.pBestTrack->GetTrackStateAtCalorimeter(); 
-    const pandora::CartesianVector &rp  = tsAtCalo.GetPosition();
-    const pandora::CartesianVector &mom = tsAtCalo.GetMomentum();
+    const pandora::TrackState& tsAtCalo = s.pBestTrack->GetTrackStateAtCalorimeter();
+    const pandora::CartesianVector& rp = tsAtCalo.GetPosition();
+    const pandora::CartesianVector& mom = tsAtCalo.GetMomentum();
     const float pz = mom.GetZ();
 
     // Magnetic field for the helix.  UseBfieldAtIP (default) takes the field at the IP
@@ -210,8 +205,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
     // at the extrapolation START point (the track state at the calorimeter) instead.
     // Note that pandora::Helix itself assumes a constant field
     // a fair approximation over the short ECAL -> HCAL surface step.
-    const pandora::CartesianVector bFieldPosition =
-        m_useBFieldAtIP ? pandora::CartesianVector(0.f, 0.f, 0.f) : rp;
+    const pandora::CartesianVector bFieldPosition = m_useBFieldAtIP ? pandora::CartesianVector(0.f, 0.f, 0.f) : rp;
     const float bField = PandoraContentApi::GetPlugins(*this)->GetBFieldPlugin()->GetBField(bFieldPosition);
 
     // extrapolation based on the track state at calo
@@ -219,8 +213,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
 
     // Try barrel intersection
     pandora::CartesianVector barrelPoint(0.f, 0.f, 0.f);
-    const pandora::StatusCode scBarrel =
-        helix.GetPointOnCircle(m_hcalSurfaceR, rp, barrelPoint);
+    const pandora::StatusCode scBarrel = helix.GetPointOnCircle(m_hcalSurfaceR, rp, barrelPoint);
     const float barrelTime = (barrelPoint.GetZ() - rp.GetZ()) / pz;
 
     // Try endcap intersection (correct sign from momentum z-component).  Skipped for a
@@ -234,10 +227,8 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
       const float targetZ = (pz >= 0.f) ? m_hcalSurfaceZHalf : -m_hcalSurfaceZHalf;
       const pandora::StatusCode scEndcap = helix.GetPointInZ(targetZ, rp, endcapPoint);
       endcapTime = (endcapPoint.GetZ() - rp.GetZ()) / pz;
-      const float endcapR2 = endcapPoint.GetX()*endcapPoint.GetX() +
-                             endcapPoint.GetY()*endcapPoint.GetY();
-      endcapOk = (scEndcap == pandora::STATUS_CODE_SUCCESS) &&
-                 (endcapR2 <= m_hcalSurfaceR * m_hcalSurfaceR) &&
+      const float endcapR2 = endcapPoint.GetX() * endcapPoint.GetX() + endcapPoint.GetY() * endcapPoint.GetY();
+      endcapOk = (scEndcap == pandora::STATUS_CODE_SUCCESS) && (endcapR2 <= m_hcalSurfaceR * m_hcalSurfaceR) &&
                  (endcapTime > 0.f); // require forward extrapolation in time
     }
 
@@ -264,11 +255,10 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
     impact.GetSphericalCoordinates(_, phImpact, thImpact);
     rp.GetSphericalCoordinates(_, phCalo, thCalo);
     if (VectorHelper::AngularDR(thImpact, phImpact, thCalo, phCalo) > m_maxSearchDeltaR)
-      return pandora::STATUS_CODE_FAILURE; // fail silently (likely low pT tracks)    
+      return pandora::STATUS_CODE_FAILURE; // fail silently (likely low pT tracks)
   } else {
     // Neutral seed: project ECAL centroid radially through origin
-    const pandora::CartesianVector &centroid =
-        s.pEcalCluster->GetCentroid(s.pEcalCluster->GetInnerPseudoLayer());
+    const pandora::CartesianVector& centroid = s.pEcalCluster->GetCentroid(s.pEcalCluster->GetInnerPseudoLayer());
     float th, ph, _;
     centroid.GetSphericalCoordinates(_, ph, th);
     ProjectThetaPhiToHcalFace(th, ph, impact);
@@ -281,19 +271,18 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(Seed
   return pandora::STATUS_CODE_SUCCESS;
 } // ExtrapolateToHcalSurface
 
-void EcalSeededClusteringAlgorithm::ProjectThetaPhiToHcalFace(float theta,
-                                                              float phi,
-                                                              pandora::CartesianVector &out) const {
+void EcalSeededClusteringAlgorithm::ProjectThetaPhiToHcalFace(float theta, float phi,
+                                                              pandora::CartesianVector& out) const {
   const float thetaTrans = std::atan2(m_hcalSurfaceR, m_hcalSurfaceZHalf);
-  const bool  barrel   = (theta > thetaTrans) && (theta < (static_cast<float>(M_PI) - thetaTrans));
+  const bool barrel = (theta > thetaTrans) && (theta < (static_cast<float>(M_PI) - thetaTrans));
 
   if (barrel) {
     const float rho = m_hcalSurfaceR;
     // for a barrel point: x=r*cos(phi), y=r*sin(phi), z=r/tan(theta)
-    const float z   = rho / std::tan(theta);
+    const float z = rho / std::tan(theta);
     out = pandora::CartesianVector(rho * std::cos(phi), rho * std::sin(phi), z);
   } else {
-    const float z   = (std::cos(theta) >= 0.f) ? m_hcalSurfaceZHalf : -m_hcalSurfaceZHalf;
+    const float z = (std::cos(theta) >= 0.f) ? m_hcalSurfaceZHalf : -m_hcalSurfaceZHalf;
     // z and tan(theta) always share the same sign here (both >0 for +z endcap,
     // both <0 for -z endcap), so z*tan(theta) is always positive.
     const float rho = z * std::tan(theta);
@@ -305,16 +294,16 @@ void EcalSeededClusteringAlgorithm::ProjectThetaPhiToHcalFace(float theta,
 //  Phase 2b - BuildVicinities
 // ====================================================================== //
 
-void EcalSeededClusteringAlgorithm::BuildVicinities(std::vector<SeededCluster> &seeds,
-                                                    const std::vector<HitCache> &hcalPool) const {
+void EcalSeededClusteringAlgorithm::BuildVicinities(std::vector<SeededCluster>& seeds,
+                                                    const std::vector<HitCache>& hcalPool) const {
   const float maxDR2 = m_maxSearchDeltaR * m_maxSearchDeltaR;
-  for (auto &s : seeds) {
+  for (auto& s : seeds) {
     s.vicinity.clear();
 
     if (!s.alive)
       continue;
 
-    for (const auto &hc : hcalPool) {
+    for (const auto& hc : hcalPool) {
       if (VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, hc.theta, hc.phi) < maxDR2)
         s.vicinity.push_back(&hc);
     } // loop over hcalPool
@@ -325,45 +314,43 @@ void EcalSeededClusteringAlgorithm::BuildVicinities(std::vector<SeededCluster> &
 //  Phase 3a - FormSeedCircles
 // ====================================================================== //
 
-void EcalSeededClusteringAlgorithm::FormSeedCircles(std::vector<SeededCluster> &seeds,
-                                                    SeedCircleMap &circles) const {
+void EcalSeededClusteringAlgorithm::FormSeedCircles(std::vector<SeededCluster>& seeds, SeedCircleMap& circles) const {
   for (std::size_t i = 0; i < seeds.size(); ++i) {
-    SeededCluster &s = seeds[i];
+    SeededCluster& s = seeds[i];
     if (!s.alive)
       continue;
 
     // Strip search window (half-widths) around the projected impact direction.
     const float halfDTheta = 0.5f * (s.isCharged ? m_stripDThetaCharged : m_stripDThetaNeutral);
-    const float halfDPhi   = 0.5f * (s.isCharged ? m_stripDPhiCharged   : m_stripDPhiNeutral);
+    const float halfDPhi = 0.5f * (s.isCharged ? m_stripDPhiCharged : m_stripDPhiNeutral);
 
     // Collect candidate anchor hits inside the (theta, phi) strip, ordered by
     // opening-angle distance to the projection so the FIRST one passing the
     // density cut is automatically the closest qualifying anchor.
-    std::vector<const HitCache *> candidates;
-    for (const HitCache *hc : s.vicinity) {
+    std::vector<const HitCache*> candidates;
+    for (const HitCache* hc : s.vicinity) {
       if (std::fabs(hc->theta - s.thetaSeed) > halfDTheta)
         continue;
       if (std::fabs(VectorHelper::deltaPhi(hc->phi, s.phiSeed)) > halfDPhi)
         continue;
       candidates.push_back(hc);
     }
-    std::sort(candidates.begin(), candidates.end(),
-              [&s](const HitCache *a, const HitCache *b) {
-                return VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, a->theta, a->phi) <
-                       VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, b->theta, b->phi);
-              });
+    std::sort(candidates.begin(), candidates.end(), [&s](const HitCache* a, const HitCache* b) {
+      return VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, a->theta, a->phi) <
+             VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, b->theta, b->phi);
+    });
 
     // For each candidate (closest first) build its m_seedCircleRadius disk; the
     // first whose scintillation sum passes m_rhoSeed becomes the seed circle.
-    std::vector<const HitCache *> circle;
+    std::vector<const HitCache*> circle;
     bool found = false;
-    for (const HitCache *anchor : candidates) {
+    for (const HitCache* anchor : candidates) {
       const float r_anchor = anchor->pos.GetMagnitude();
       const float cosCut = r_anchor / std::sqrt(r_anchor * r_anchor + m_seedCircleRadius * m_seedCircleRadius);
 
       circle.clear();
       float scintSum = 0.f;
-      for (const HitCache *hc : s.vicinity) {
+      for (const HitCache* hc : s.vicinity) {
         if (hc->energy < m_growThreshold)
           continue;
         if (anchor->pos.GetCosOpeningAngle(hc->pos) > cosCut) {
@@ -393,28 +380,31 @@ void EcalSeededClusteringAlgorithm::FormSeedCircles(std::vector<SeededCluster> &
 //  Phase 3b - ResolveSeedCircleContests
 // ====================================================================== //
 
-void EcalSeededClusteringAlgorithm::ResolveSeedCircleContests(std::vector<SeededCluster> &seeds,
-                                                              SeedCircleMap &circles) const {
+void EcalSeededClusteringAlgorithm::ResolveSeedCircleContests(std::vector<SeededCluster>& seeds,
+                                                              SeedCircleMap& circles) const {
   // Build hit -> {seed indices} map
-  std::map<const HitCache *, std::vector<int>> contestants;
-  for (const auto &[idx, circle] : circles)
-    for (const HitCache *hc : circle)
+  std::map<const HitCache*, std::vector<int>> contestants;
+  for (const auto& [idx, circle] : circles)
+    for (const HitCache* hc : circle)
       contestants[hc].push_back(idx);
 
   // Resolve each contested hit with opening angle to the seed impact point
-  for (const auto &[hc, owners] : contestants) {
+  for (const auto& [hc, owners] : contestants) {
     if (owners.size() < 2)
       continue;
 
     // Pick winner: lowest opening-angle distance
-    int   winner = owners[0];
+    int winner = owners[0];
     float bestDist = std::numeric_limits<float>::max();
     for (int idx : owners) {
       if (!seeds[idx].alive)
         continue;
 
       const float d = OpeningAngleDist(seeds[idx].hcalImpactPoint, hc->pos);
-      if (d < bestDist) { bestDist = d; winner = idx; }
+      if (d < bestDist) {
+        bestDist = d;
+        winner = idx;
+      }
     } // loop over contestants for this hit
 
     // Remove from all losers
@@ -422,7 +412,7 @@ void EcalSeededClusteringAlgorithm::ResolveSeedCircleContests(std::vector<Seeded
       if (idx == winner)
         continue;
 
-      auto &cl = circles[idx];
+      auto& cl = circles[idx];
       cl.erase(std::remove(cl.begin(), cl.end(), hc), cl.end());
 
       if (cl.empty())
@@ -435,22 +425,22 @@ void EcalSeededClusteringAlgorithm::ResolveSeedCircleContests(std::vector<Seeded
 //  ComputeClusterState
 // ====================================================================== //
 
-void EcalSeededClusteringAlgorithm::ComputeClusterState(ClusterState &gc) const {
+void EcalSeededClusteringAlgorithm::ComputeClusterState(ClusterState& gc) const {
   float scintSum = 0.f, cherenSum = 0.f, totE = 0.f;
-  for (const HitCache *hc : gc.hits) {
+  for (const HitCache* hc : gc.hits) {
     totE += hc->energy;
-    if (hc->isCheren) cherenSum += hc->energy;
-    else              scintSum  += hc->energy;
+    if (hc->isCheren)
+      cherenSum += hc->energy;
+    else
+      scintSum += hc->energy;
   }
 
-  gc.energy = m_useDualReadout
-      ? (scintSum - m_chiHcal * cherenSum) / (1.f - m_chiHcal)
-      : totE;
+  gc.energy = m_useDualReadout ? (scintSum - m_chiHcal * cherenSum) / (1.f - m_chiHcal) : totE;
 
   pandora::CartesianVector bary(0.f, 0.f, 0.f);
   float totW = 0.f;
   if (totE > 0.f) {
-    for (const HitCache *hc : gc.hits) {
+    for (const HitCache* hc : gc.hits) {
       const float w = std::max(0.f, m_w0 + std::log(hc->energy / totE));
       if (w > 0.f) {
         bary += hc->pos * w;
@@ -459,8 +449,7 @@ void EcalSeededClusteringAlgorithm::ComputeClusterState(ClusterState &gc) const 
     } // loop over hits in cluster
   }
 
-  gc.barycenter = (totW > 0.f) ? bary * (1.f / totW)
-                                : pandora::CartesianVector(0.f, 0.f, 0.f);
+  gc.barycenter = (totW > 0.f) ? bary * (1.f / totW) : pandora::CartesianVector(0.f, 0.f, 0.f);
 } // ComputeClusterState
 
 // ====================================================================== //
@@ -468,9 +457,8 @@ void EcalSeededClusteringAlgorithm::ComputeClusterState(ClusterState &gc) const 
 // ====================================================================== //
 
 std::vector<EcalSeededClusteringAlgorithm::ClusterState>
-EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
-                                    const std::vector<ClusterState> &clusters,
-                                    pandora::CaloHitSet &assignedSet) const {
+EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy, const std::vector<ClusterState>& clusters,
+                                    pandora::CaloHitSet& assignedSet) const {
   std::vector<ClusterState> result(clusters); // working copy
   const int n = static_cast<int>(result.size());
   if (n == 0)
@@ -480,7 +468,7 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
 
   // Per-cluster frontier: hits added in the last layer.
   // Initialised from each cluster's seed-circle hits.
-  std::map<int, std::vector<const HitCache *>> frontier;
+  std::map<int, std::vector<const HitCache*>> frontier;
   for (int i = 0; i < n; ++i)
     frontier[i] = result[i].hits;
 
@@ -488,26 +476,29 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
   std::vector<int> rep(n);
   std::iota(rep.begin(), rep.end(), 0);
   auto findRep = [&rep](int x) -> int {
-    while (rep[x] != x) { rep[x] = rep[rep[x]]; x = rep[x]; }
+    while (rep[x] != x) {
+      rep[x] = rep[rep[x]];
+      x = rep[x];
+    }
     return x;
   };
   auto mergeReps = [&rep, &findRep](int a, int b) {
-    a = findRep(a); b = findRep(b);
-    if (a != b) rep[b] = a;
+    a = findRep(a);
+    b = findRep(b);
+    if (a != b)
+      rep[b] = a;
   };
 
   // Shared lambda: accumulate candidates from a (frontier, vicinity) pair into
   // the candidates map, keyed by the given cluster index / representative id.
-  auto collectCandidates = [&](std::map<const HitCache *, std::vector<int>> &candidates,
-                               int id,
-                               const std::vector<const HitCache *> &front,
-                               const auto &vicinity) {
-    for (const HitCache *fhc : front) {
+  auto collectCandidates = [&](std::map<const HitCache*, std::vector<int>>& candidates, int id,
+                               const std::vector<const HitCache*>& front, const auto& vicinity) {
+    for (const HitCache* fhc : front) {
       // Max opening angle for adjacency: atan2(adjCut, r_fhc)
-      const float r_fhc  = fhc->pos.GetMagnitude();
+      const float r_fhc = fhc->pos.GetMagnitude();
       const float cosCut = r_fhc / std::sqrt(r_fhc * r_fhc + adjCut * adjCut);
 
-      for (const HitCache *nb : vicinity) {
+      for (const HitCache* nb : vicinity) {
         if (assignedSet.count(nb->pHit))
           continue;
         if (nb->energy < m_growThreshold)
@@ -519,7 +510,7 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
   };
 
   // Shared lambda: deduplicate a sorted-or-unsorted claimers vector in-place.
-  auto deduplicateClaimers = [](std::vector<int> &claimers) {
+  auto deduplicateClaimers = [](std::vector<int>& claimers) {
     std::sort(claimers.begin(), claimers.end());
     claimers.erase(std::unique(claimers.begin(), claimers.end()), claimers.end());
   };
@@ -533,21 +524,24 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
     //  ResolveByDist: each cluster searches its own vicinity independently.
     //  MergeClusters: build per-representative vicinity union, then search.
     // ---------------------------------------------------------------- //
-    std::map<int, std::vector<const HitCache *>> nextFrontier;
+    std::map<int, std::vector<const HitCache*>> nextFrontier;
 
     if (strategy == GrowStrategy::ResolveByDist) {
-      std::map<const HitCache *, std::vector<int>> candidates;
+      std::map<const HitCache*, std::vector<int>> candidates;
       for (int i = 0; i < n; ++i)
         collectCandidates(candidates, i, frontier[i], result[i].vicinity);
 
-      for (auto &[hc, claimers] : candidates) {
+      for (auto& [hc, claimers] : candidates) {
         deduplicateClaimers(claimers);
 
-        int   winner = claimers[0];
+        int winner = claimers[0];
         float bestDist = std::numeric_limits<float>::max();
         for (int idx : claimers) {
           const float d = OpeningAngleDist(result[idx].barycenter, hc->pos);
-          if (d < bestDist) { bestDist = d; winner = idx; }
+          if (d < bestDist) {
+            bestDist = d;
+            winner = idx;
+          }
         }
         assignedSet.insert(hc->pHit);
         result[winner].hits.push_back(hc);
@@ -556,24 +550,24 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
       } // loop over candidates
 
       // recompute cluster states
-      for (const auto &[i, _] : nextFrontier)
+      for (const auto& [i, _] : nextFrontier)
         ComputeClusterState(result[i]);
     } else { // MergeClusters: collapse frontier and vicinity into per-representative sets
-      std::map<int, std::vector<const HitCache *>> repFront;
-      std::map<int, std::set<const HitCache *>> repVicinity;
+      std::map<int, std::vector<const HitCache*>> repFront;
+      std::map<int, std::set<const HitCache*>> repVicinity;
       for (int i = 0; i < n; ++i) {
         const int r = findRep(i);
-        for (const HitCache *hc : frontier[i])
+        for (const HitCache* hc : frontier[i])
           repFront[r].push_back(hc);
-        for (const HitCache *hc : result[i].vicinity)
+        for (const HitCache* hc : result[i].vicinity)
           repVicinity[r].insert(hc);
       } // loop over clusters to build repFront and repVicinity
 
-      std::map<const HitCache *, std::vector<int>> candidates;
-      for (const auto &[r, fr] : repFront)
+      std::map<const HitCache*, std::vector<int>> candidates;
+      for (const auto& [r, fr] : repFront)
         collectCandidates(candidates, r, fr, repVicinity[r]);
 
-      for (auto &[hc, claimers] : candidates) {
+      for (auto& [hc, claimers] : candidates) {
         deduplicateClaimers(claimers);
 
         int winner = findRep(claimers[0]);
@@ -599,9 +593,9 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
         continue;
 
       // Merge hits and vicinity into representative cluster
-      for (const HitCache *hc : result[i].hits)
+      for (const HitCache* hc : result[i].hits)
         result[r].hits.push_back(hc);
-      for (const HitCache *hc : result[i].vicinity)
+      for (const HitCache* hc : result[i].vicinity)
         result[r].vicinity.push_back(hc);
 
       // Clear the non-representative cluster's hits and vicinity.
@@ -611,10 +605,8 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
     } // loop over clusters to merge into representatives
 
     // Single erase pass after the loop: remove all now-empty non-representatives.
-    result.erase(
-        std::remove_if(result.begin(), result.end(),
-                       [](const ClusterState &gc) { return gc.hits.empty(); }),
-        result.end());
+    result.erase(std::remove_if(result.begin(), result.end(), [](const ClusterState& gc) { return gc.hits.empty(); }),
+                 result.end());
   } // if MergeClusters
 
   return result;
@@ -624,11 +616,11 @@ EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
 //  Phases 2–4 - FormSeededClusters
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vector<SeededCluster> &seeds,
-                                                                      const std::vector<HitCache> &hcalPool,
-                                                                      pandora::CaloHitSet &assignedSet) const {
+pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vector<SeededCluster>& seeds,
+                                                                      const std::vector<HitCache>& hcalPool,
+                                                                      pandora::CaloHitSet& assignedSet) const {
   // ---- Phase 2a: project seeds onto HCAL surface ----
-  for (auto &s : seeds) {
+  for (auto& s : seeds) {
     if (ExtrapolateToHcalSurface(s) != pandora::STATUS_CODE_SUCCESS)
       s.alive = false;
   }
@@ -653,9 +645,9 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vecto
     aliveIdx.push_back(i);
 
     ClusterState cs;
-    cs.hits     = circles[i];       // HitCache* directly - no map lookup needed
+    cs.hits = circles[i];            // HitCache* directly - no map lookup needed
     cs.vicinity = seeds[i].vicinity; // search space for this seed
-    for (const HitCache *hc : cs.hits)
+    for (const HitCache* hc : cs.hits)
       assignedSet.insert(hc->pHit);
 
     ComputeClusterState(cs);
@@ -666,7 +658,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vecto
 
   // Write grown state back into each SeededCluster (inherits ClusterState).
   for (int j = 0; j < static_cast<int>(aliveIdx.size()); ++j) {
-    auto &s = seeds[aliveIdx[j]];
+    auto& s = seeds[aliveIdx[j]];
     s.hits = grown[j].hits;
     ComputeClusterState(s);
   }
@@ -678,13 +670,13 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vecto
 //  Phase 5 - FormUnseededClusters
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vector<UnseededCluster> &unseeded,
-                                                                        const std::vector<HitCache> &hcalPool,
-                                                                        pandora::CaloHitSet &assignedSet) const {
+pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vector<UnseededCluster>& unseeded,
+                                                                        const std::vector<HitCache>& hcalPool,
+                                                                        pandora::CaloHitSet& assignedSet) const {
   // Collect remaining HCAL hits not consumed by Phase 4.
-  std::vector<const HitCache *> remaining;
+  std::vector<const HitCache*> remaining;
   remaining.reserve(hcalPool.size());
-  for (const auto &hc : hcalPool) {
+  for (const auto& hc : hcalPool) {
     if (!assignedSet.count(hc.pHit))
       remaining.push_back(&hc);
   }
@@ -694,7 +686,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vec
 
   // Sort by descending energy for reproducible seeding order.
   std::sort(remaining.begin(), remaining.end(),
-            [](const HitCache *a, const HitCache *b) { return a->energy > b->energy; });
+            [](const HitCache* a, const HitCache* b) { return a->energy > b->energy; });
 
   // ------------------------------------------------------------------ //
   //  Step A: find candidate seed centers - local scint circle sum >= rhoUnseeded.
@@ -704,14 +696,14 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vec
   std::vector<ClusterState> initStates;
   const float maxDR2 = m_maxSearchDeltaR * m_maxSearchDeltaR;
 
-  for (const HitCache *center : remaining) {
+  for (const HitCache* center : remaining) {
     // Max opening angles for this center hit: atan2(cut, r_center)
-    const float r_center   = center->pos.GetMagnitude();
+    const float r_center = center->pos.GetMagnitude();
     const float cosSeedCut = r_center / std::sqrt(r_center * r_center + m_seedCircleRadius * m_seedCircleRadius);
 
     float scintSum = 0.f;
     ClusterState gc;
-    for (const HitCache *nb : remaining) {
+    for (const HitCache* nb : remaining) {
       const float dr2 = VectorHelper::AngularDR2(center->theta, center->phi, nb->theta, nb->phi);
 
       // Vicinity: all hits in range, regardless of threshold or circle ownership
@@ -737,7 +729,7 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vec
     if (scintSum < m_rhoUnseeded)
       continue;
 
-    for (const HitCache *hc : gc.hits)
+    for (const HitCache* hc : gc.hits)
       circleAssigned.insert(hc->pHit);
 
     ComputeClusterState(gc);
@@ -751,14 +743,14 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vec
   //  BFS with merge-on-contest via shared Grow().
   //  Pre-assign circle hits so Grow() won't re-claim them.
   // ------------------------------------------------------------------ //
-  for (const auto &gc : initStates)
-    for (const HitCache *hc : gc.hits)
+  for (const auto& gc : initStates)
+    for (const HitCache* hc : gc.hits)
       assignedSet.insert(hc->pHit);
 
   auto result = Grow(GrowStrategy::MergeClusters, initStates, assignedSet);
 
   // Emit one UnseededCluster per surviving root.
-  for (auto &gc : result) {
+  for (auto& gc : result) {
     if (gc.hits.empty())
       continue;
 
@@ -775,57 +767,58 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vec
 //  Phase 6 - WriteBack
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::WriteBack(std::vector<SeededCluster> &seeds,
-                                                             std::vector<UnseededCluster> &unseeded) const {
+pandora::StatusCode EcalSeededClusteringAlgorithm::WriteBack(std::vector<SeededCluster>& seeds,
+                                                             std::vector<UnseededCluster>& unseeded) const {
   // Extend each surviving ECAL cluster with its HCAL hits
-  for (auto &s : seeds) {
+  for (auto& s : seeds) {
     if (!s.alive || s.hits.empty())
       continue;
 
-    for (const HitCache *hc : s.hits) {
+    for (const HitCache* hc : s.hits) {
       PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-          PandoraContentApi::AddToCluster(*this, s.pEcalCluster, hc->pHit));
+                               PandoraContentApi::AddToCluster(*this, s.pEcalCluster, hc->pHit));
     }
   }
 
   // Get current list name before proceeding
   std::string inputClusterListName;
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::GetCurrentListName<pandora::Cluster>(*this, inputClusterListName));
+                           PandoraContentApi::GetCurrentListName<pandora::Cluster>(*this, inputClusterListName));
 
   // Recreate cluster list within the pandora framework
   // (this will allow creating new objects)
   const pandora::ClusterList* pClusterList = nullptr;
   std::string clusterListName = m_outputClusterListName + "Tmp";
 
-  PANDORA_RETURN_RESULT_IF(
-      pandora::STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListName));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListName));
 
   // Create new clusters for unseeded HCAL clusters
-  for (auto &u : unseeded) {
+  for (auto& u : unseeded) {
     pandora::CaloHitList hitList;
-    for (const HitCache *hc : u.hits)
+    for (const HitCache* hc : u.hits)
       hitList.push_back(hc->pHit);
 
-    const pandora::Cluster *pNewCluster = nullptr;
+    const pandora::Cluster* pNewCluster = nullptr;
     PandoraContentApi::Cluster::Parameters params;
     params.m_caloHitList = hitList;
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-        PandoraContentApi::Cluster::Create(*this, params, pNewCluster));
+                             PandoraContentApi::Cluster::Create(*this, params, pNewCluster));
   }
 
   // need these to store the pandora cluster list
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // save the previous list to the new output (seeded clusters)
-                            PandoraContentApi::SaveList<pandora::Cluster>(*this, inputClusterListName, m_outputClusterListName));
+  PANDORA_RETURN_RESULT_IF(
+      pandora::STATUS_CODE_SUCCESS, !=, // save the previous list to the new output (seeded clusters)
+      PandoraContentApi::SaveList<pandora::Cluster>(*this, inputClusterListName, m_outputClusterListName));
 
   if (!unseeded.empty()) { // only replace the current list if we actually created new clusters
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // save the current list to the new output (unseeded clusters)
-                              PandoraContentApi::SaveList<pandora::Cluster>(*this, m_outputClusterListName));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS,
+                             !=, // save the current list to the new output (unseeded clusters)
+                             PandoraContentApi::SaveList<pandora::Cluster>(*this, m_outputClusterListName));
   }
 
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // make the new output the current list
-                            PandoraContentApi::ReplaceCurrentList<pandora::Cluster>(*this, m_outputClusterListName));
+                           PandoraContentApi::ReplaceCurrentList<pandora::Cluster>(*this, m_outputClusterListName));
 
   return pandora::STATUS_CODE_SUCCESS;
 }
@@ -834,9 +827,9 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::WriteBack(std::vector<SeededC
 //  Helper functions
 // ====================================================================== //
 
-float EcalSeededClusteringAlgorithm::OpeningAngleDist(const pandora::CartesianVector &clusDir,
-                                                      const pandora::CartesianVector &hitPos) const {
-  const float r_hit  = hitPos.GetMagnitude();
+float EcalSeededClusteringAlgorithm::OpeningAngleDist(const pandora::CartesianVector& clusDir,
+                                                      const pandora::CartesianVector& hitPos) const {
+  const float r_hit = hitPos.GetMagnitude();
   const float r_clus = clusDir.GetMagnitude();
   if (r_hit <= 0.f || r_clus <= 0.f)
     return std::numeric_limits<float>::max();
@@ -846,11 +839,9 @@ float EcalSeededClusteringAlgorithm::OpeningAngleDist(const pandora::CartesianVe
   return 1.f - cosA;
 } // OpeningAngleDist
 
-bool EcalSeededClusteringAlgorithm::IsHcalHit(const pandora::CaloHit *h) const {
-  return h->GetHadronicEnergy() > 0.f;
-}
+bool EcalSeededClusteringAlgorithm::IsHcalHit(const pandora::CaloHit* h) const { return h->GetHadronicEnergy() > 0.f; }
 
-bool EcalSeededClusteringAlgorithm::IsCherenkovHit(const pandora::CaloHit *h) const {
+bool EcalSeededClusteringAlgorithm::IsCherenkovHit(const pandora::CaloHit* h) const {
   return h->GetHitType() == pandora::DRC_CHEREN;
 }
 
@@ -859,7 +850,7 @@ bool EcalSeededClusteringAlgorithm::IsCherenkovHit(const pandora::CaloHit *h) co
 // ====================================================================== //
 
 pandora::StatusCode EcalSeededClusteringAlgorithm::ReadHcalGeometry() {
-  const pandora::GeometryManager *const pGeometry = PandoraContentApi::GetGeometry(*this);
+  const pandora::GeometryManager* const pGeometry = PandoraContentApi::GetGeometry(*this);
 
   if (!pGeometry)
     return pandora::STATUS_CODE_NOT_INITIALIZED;
@@ -872,8 +863,8 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ReadHcalGeometry() {
   // the z half-length is then effectively infinite, so every direction lands on the barrel.
   try {
     m_hcalSurfaceZHalf = pGeometry->GetSubDetector(pandora::HCAL_ENDCAP).GetInnerZCoordinate();
-  } catch (const pandora::StatusCodeException &) {
-    m_hasHcalEndcap    = false;
+  } catch (const pandora::StatusCodeException&) {
+    m_hasHcalEndcap = false;
     m_hcalSurfaceZHalf = std::numeric_limits<float>::max();
   }
 
@@ -887,44 +878,45 @@ pandora::StatusCode EcalSeededClusteringAlgorithm::ReadHcalGeometry() {
 //  ReadSettings
 // ====================================================================== //
 
-pandora::StatusCode EcalSeededClusteringAlgorithm::ReadSettings(
-    const pandora::TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+pandora::StatusCode EcalSeededClusteringAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF_AND_IF(
+      pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
       pandora::XmlHelper::ReadValue(xmlHandle, "OutputClusterListName", m_outputClusterListName));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "UseDualReadout", m_useDualReadout));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "UseDualReadout", m_useDualReadout));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "MomentumThreshold", m_pThres));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "MomentumThreshold", m_pThres));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "HardThreshold", m_hardThreshold));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "HardThreshold", m_hardThreshold));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "GrowThreshold", m_growThreshold));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "GrowThreshold", m_growThreshold));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "MaxSearchDR", m_maxSearchDeltaR));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "MaxSearchDR", m_maxSearchDeltaR));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "SeedCircleR", m_seedCircleRadius));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "SeedCircleR", m_seedCircleRadius));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaCharged", m_stripDThetaCharged));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaCharged", m_stripDThetaCharged));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiCharged", m_stripDPhiCharged));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiCharged", m_stripDPhiCharged));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaNeutral", m_stripDThetaNeutral));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaNeutral", m_stripDThetaNeutral));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiNeutral", m_stripDPhiNeutral));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiNeutral", m_stripDPhiNeutral));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "AdjacencyR", m_adjacencyRadius));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "AdjacencyR", m_adjacencyRadius));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "SeedThreshold", m_rhoSeed));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "SeedThreshold", m_rhoSeed));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "UnseededThreshold", m_rhoUnseeded));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "UnseededThreshold", m_rhoUnseeded));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
+  PANDORA_RETURN_RESULT_IF_AND_IF(
+      pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
       pandora::XmlHelper::ReadValue(xmlHandle, "ChargedEcalOverPMax", m_chargedEcalOverPMax));
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "UseBfieldAtIP", m_useBFieldAtIP));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "UseBfieldAtIP", m_useBFieldAtIP));
 
   // The HCAL inner surface comes from the detector geometry, not from XML.
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->ReadHcalGeometry());

--- a/src/LCClustering/EcalSeededClusteringAlgorithm.cc
+++ b/src/LCClustering/EcalSeededClusteringAlgorithm.cc
@@ -1,0 +1,944 @@
+/**
+ *  @file   LCContent/src/LCClustering/EcalSeededClusteringAlgorithm.cc
+ *
+ *  @brief  Implementation of the ECAL-seeded HCAL clustering algorithm.
+ *
+ *  Phase summary
+ *  -------------
+ *   1a  SelectSeeds    - filter ECAL clusters into SeededCluster list
+ *   1b  BuildHcalPool    - cache all HCAL hits above HardThreshold
+ *   2a  ExtrapolateToHcal  - project each seed onto the HCAL inner face
+ *   2b  BuildVicinities  - restrict per-seed work to dR < MaxSearchDeltaR
+ *   3   FormSeedCircles +  - initial seed-circle frontier + contest resolution
+ *       ResolveSeedCircleContests
+ *   4   GrowSeeds     - layer-by-layer BFS within each seed's vicinity
+ *   5   FormUnseededClusters - BFS+union-find for hits not claimed in Phase 4
+ *   6   WriteBack      - AddToCluster / Cluster::Create
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Api/PandoraContentApi.h"
+#include "Objects/Track.h"
+#include "Objects/Cluster.h"
+#include "Objects/CaloHit.h"
+#include "Objects/Helix.h"
+
+#include "LCClustering/EcalSeededClusteringAlgorithm.h"
+#include "LCHelpers/VectorHelper.h"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace lc_content {
+
+// ====================================================================== //
+//  Run
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::Run() {
+  // ---- get Pandora input lists ----
+  // assume all existing clusters are ECAL clusters
+  const pandora::ClusterList *pEcalClusterList  = nullptr;
+  const pandora::CaloHitList *pCurrentCaloHitList = nullptr;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentList(*this, pEcalClusterList));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentList(*this, pCurrentCaloHitList));
+
+  // ---- Phase 1a: ECAL seed selection ----
+  std::vector<SeededCluster> seeds;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      SelectSeeds(*pEcalClusterList, seeds));
+
+  // ---- Phase 1b: HCAL hit pool ----
+  std::vector<HitCache> hcalPool; // this is the owner of the cached hit info
+  BuildHcalPool(*pCurrentCaloHitList, hcalPool);
+
+  if (hcalPool.empty()) // nothing to do
+    return pandora::STATUS_CODE_SUCCESS;
+
+  // ---- Phases 2–4: seed-driven work (skipped when no seeds) ----
+  pandora::CaloHitSet assignedSet;
+
+  if (!seeds.empty()) {
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+        FormSeededClusters(seeds, hcalPool, assignedSet));
+  }
+
+  // ---- Phase 5: unseeded clusters from leftover hits ----
+  // Runs regardless of whether any ECAL seeds were present.
+  std::vector<UnseededCluster> unseeded;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      FormUnseededClusters(unseeded, hcalPool, assignedSet));
+
+  // ---- Phase 6: write back to Pandora ----
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      WriteBack(seeds, unseeded));
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+// ====================================================================== //
+//  Phase 1a - SelectSeeds
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::SelectSeeds(const pandora::ClusterList &ecalClusters,
+                                                               std::vector<SeededCluster> &seeds) const {
+  // loop over ECAL clusters and filter out
+  for (const pandora::Cluster *const pClus : ecalClusters) {
+    if (!pClus->IsAvailable())
+      continue;
+
+    SeededCluster s;
+    s.pEcalCluster = pClus;
+
+    const auto &tracks = pClus->GetAssociatedTrackList();
+    if (tracks.empty()) {
+      // Only grow HCAL behind neutral clusters tagged as neutral hadrons by the
+      // external PID (cluster particleId == K_LONG, set upstream from the edm4hep
+      // cluster type). Photons, satellites and unidentified neutral clusters are
+      // skipped.
+      if (pClus->GetParticleId() != pandora::K_LONG)
+        continue;
+
+      s.isCharged  = false;
+      s.pBestTrack = nullptr;
+    } else {
+      // Charged cluster: take the highest-momentum associated track
+      const pandora::Track *bestTrack = nullptr;
+      float bestP = 0.f;
+      for (const auto *t : tracks) {
+        const float p = t->GetMomentumAtDca().GetMagnitude();
+
+        if (p > bestP) {
+          bestP = p;
+          bestTrack = t;
+        }
+      } // loop over associated tracks
+
+      // Drop seeds below momentum threshold
+      if (bestP < m_pThres)
+        continue;
+
+      // E_DR_ECAL/p gate: a charged cluster that already deposited most of its
+      // momentum in the ECAL has little real HCAL behind it, so growing would only
+      // attach a neighbour's HCAL (fake). The DR (dual-readout) correction is
+      // returned in the hadronic slot; this algorithm runs before HCAL growing so
+      // the cluster is ECAL-only and corrHad is just E_DR_ECAL.
+      float eEcal = 0.f;
+      if (m_useDualReadout) {
+        const pandora::EnergyCorrections *const pCorr =
+            PandoraContentApi::GetPlugins(*this)->GetEnergyCorrections();
+        if (pCorr == nullptr)
+          return pandora::STATUS_CODE_FAILURE;
+
+        float corrEm = 0.f, corrHad = 0.f;
+        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+            pCorr->MakeEnergyCorrections(pClus, corrEm, corrHad));
+        eEcal = corrHad;
+      } else {
+        eEcal = pClus->GetElectromagneticEnergy();
+      }
+
+      if (eEcal >= m_chargedEcalOverPMax * bestP)
+        continue;
+
+      s.isCharged  = true;
+      s.pBestTrack = bestTrack;
+    }
+
+    seeds.push_back(std::move(s));
+  } // loop over ECAL clusters
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // SelectSeeds
+
+// ====================================================================== //
+//  Phase 1b - BuildHcalPool
+// ====================================================================== //
+
+void EcalSeededClusteringAlgorithm::BuildHcalPool(const pandora::CaloHitList &allHits,
+                                                  std::vector<HitCache> &hcalPool) const {
+  // loop over all hits and cache HCAL hits above threshold
+  hcalPool.reserve(allHits.size());
+  for (const pandora::CaloHit *const h : allHits) {
+    if (h->GetHadronicEnergy() <= 0.f)
+      continue; // skip ECAL
+    if (h->GetHadronicEnergy() < m_hardThreshold)
+      continue;
+
+    HitCache hc;
+    hc.pHit  = h;
+    hc.pos   = h->GetPositionVector();
+    hc.energy  = h->GetHadronicEnergy();
+
+    float r;
+    hc.pos.GetSphericalCoordinates(r, hc.phi, hc.theta);
+    hc.isCheren = IsCherenkovHit(h);
+    hcalPool.push_back(std::move(hc));
+  }
+} // BuildHcalPool
+
+// ====================================================================== //
+//  Phase 2a - ExtrapolateToHcalSurface
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface(SeededCluster &s) const {
+  pandora::CartesianVector impact(0.f, 0.f, 0.f);
+
+  if (s.isCharged && s.pBestTrack != nullptr) {
+    // ---------------------------------------------------------------- //
+    //  Helix extrapolation from track state at ECAL surface using
+    //  pandora::Helix::GetPointOnCircle  (barrel)  and
+    //  pandora::Helix::GetPointInZ       (endcap).
+    // ---------------------------------------------------------------- //
+    const pandora::TrackState& tsAtCalo = s.pBestTrack->GetTrackStateAtCalorimeter(); 
+    const pandora::CartesianVector &rp  = tsAtCalo.GetPosition();
+    const pandora::CartesianVector &mom = tsAtCalo.GetMomentum();
+    const float pz = mom.GetZ();
+
+    // Magnetic field for the helix.  UseBfieldAtIP (default) takes the field at the IP
+    // since exactly zero magnetic field outside the solenoid can invalidate pandora::Helix.
+    // With a realistic field map, switch the option off to evaluate the field
+    // at the extrapolation START point (the track state at the calorimeter) instead.
+    // Note that pandora::Helix itself assumes a constant field
+    // a fair approximation over the short ECAL -> HCAL surface step.
+    const pandora::CartesianVector bFieldPosition =
+        m_useBFieldAtIP ? pandora::CartesianVector(0.f, 0.f, 0.f) : rp;
+    const float bField = PandoraContentApi::GetPlugins(*this)->GetBFieldPlugin()->GetBField(bFieldPosition);
+
+    // extrapolation based on the track state at calo
+    const pandora::Helix helix(rp, mom, static_cast<float>(s.pBestTrack->GetCharge()), bField);
+
+    // Try barrel intersection
+    pandora::CartesianVector barrelPoint(0.f, 0.f, 0.f);
+    const pandora::StatusCode scBarrel =
+        helix.GetPointOnCircle(m_hcalSurfaceR, rp, barrelPoint);
+    const float barrelTime = (barrelPoint.GetZ() - rp.GetZ()) / pz;
+
+    // Try endcap intersection (correct sign from momentum z-component).  Skipped for a
+    // barrel-only geometry: m_hcalSurfaceZHalf is the infinite sentinel there, and asking the
+    // helix to intersect a plane at that z is not meaningful.
+    bool endcapOk = false;
+    pandora::CartesianVector endcapPoint(0.f, 0.f, 0.f);
+    float endcapTime = 0.f;
+
+    if (m_hasHcalEndcap) {
+      const float targetZ = (pz >= 0.f) ? m_hcalSurfaceZHalf : -m_hcalSurfaceZHalf;
+      const pandora::StatusCode scEndcap = helix.GetPointInZ(targetZ, rp, endcapPoint);
+      endcapTime = (endcapPoint.GetZ() - rp.GetZ()) / pz;
+      const float endcapR2 = endcapPoint.GetX()*endcapPoint.GetX() +
+                             endcapPoint.GetY()*endcapPoint.GetY();
+      endcapOk = (scEndcap == pandora::STATUS_CODE_SUCCESS) &&
+                 (endcapR2 <= m_hcalSurfaceR * m_hcalSurfaceR) &&
+                 (endcapTime > 0.f); // require forward extrapolation in time
+    }
+
+    const bool barrelOk = (scBarrel == pandora::STATUS_CODE_SUCCESS) &&
+                          (std::fabs(barrelPoint.GetZ()) <= m_hcalSurfaceZHalf) &&
+                          (barrelTime > 0.f); // require forward extrapolation in time
+
+    if (barrelOk && endcapOk) {
+      // Pick whichever is closer to the reference point in time
+      impact = (barrelTime <= endcapTime) ? barrelPoint : endcapPoint;
+    } else if (barrelOk) {
+      impact = barrelPoint;
+    } else if (endcapOk) {
+      impact = endcapPoint;
+    } else {
+      std::cerr << "EcalSeededClusteringAlgorithm::ExtrapolateToHcalSurface - "
+                << "Failed to extrapolate charged seed to HCAL surface" << std::endl;
+      return pandora::STATUS_CODE_FAILURE;
+    } // if barrel vs. endcap intersection
+
+    // reject if the extrapolated point is
+    // unreasonably far from the track state at calo
+    float thImpact, phImpact, thCalo, phCalo, _;
+    impact.GetSphericalCoordinates(_, phImpact, thImpact);
+    rp.GetSphericalCoordinates(_, phCalo, thCalo);
+    if (VectorHelper::AngularDR(thImpact, phImpact, thCalo, phCalo) > m_maxSearchDeltaR)
+      return pandora::STATUS_CODE_FAILURE; // fail silently (likely low pT tracks)    
+  } else {
+    // Neutral seed: project ECAL centroid radially through origin
+    const pandora::CartesianVector &centroid =
+        s.pEcalCluster->GetCentroid(s.pEcalCluster->GetInnerPseudoLayer());
+    float th, ph, _;
+    centroid.GetSphericalCoordinates(_, ph, th);
+    ProjectThetaPhiToHcalFace(th, ph, impact);
+  } // if charged vs. neutral seed
+
+  float _;
+  s.hcalImpactPoint = impact;
+  impact.GetSphericalCoordinates(_, s.phiSeed, s.thetaSeed);
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // ExtrapolateToHcalSurface
+
+void EcalSeededClusteringAlgorithm::ProjectThetaPhiToHcalFace(float theta,
+                                                              float phi,
+                                                              pandora::CartesianVector &out) const {
+  const float thetaTrans = std::atan2(m_hcalSurfaceR, m_hcalSurfaceZHalf);
+  const bool  barrel   = (theta > thetaTrans) && (theta < (static_cast<float>(M_PI) - thetaTrans));
+
+  if (barrel) {
+    const float rho = m_hcalSurfaceR;
+    // for a barrel point: x=r*cos(phi), y=r*sin(phi), z=r/tan(theta)
+    const float z   = rho / std::tan(theta);
+    out = pandora::CartesianVector(rho * std::cos(phi), rho * std::sin(phi), z);
+  } else {
+    const float z   = (std::cos(theta) >= 0.f) ? m_hcalSurfaceZHalf : -m_hcalSurfaceZHalf;
+    // z and tan(theta) always share the same sign here (both >0 for +z endcap,
+    // both <0 for -z endcap), so z*tan(theta) is always positive.
+    const float rho = z * std::tan(theta);
+    out = pandora::CartesianVector(rho * std::cos(phi), rho * std::sin(phi), z);
+  }
+} // ProjectThetaPhiToHcalFace
+
+// ====================================================================== //
+//  Phase 2b - BuildVicinities
+// ====================================================================== //
+
+void EcalSeededClusteringAlgorithm::BuildVicinities(std::vector<SeededCluster> &seeds,
+                                                    const std::vector<HitCache> &hcalPool) const {
+  const float maxDR2 = m_maxSearchDeltaR * m_maxSearchDeltaR;
+  for (auto &s : seeds) {
+    s.vicinity.clear();
+
+    if (!s.alive)
+      continue;
+
+    for (const auto &hc : hcalPool) {
+      if (VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, hc.theta, hc.phi) < maxDR2)
+        s.vicinity.push_back(&hc);
+    } // loop over hcalPool
+  } // loop over seeds
+} // BuildVicinities
+
+// ====================================================================== //
+//  Phase 3a - FormSeedCircles
+// ====================================================================== //
+
+void EcalSeededClusteringAlgorithm::FormSeedCircles(std::vector<SeededCluster> &seeds,
+                                                    SeedCircleMap &circles) const {
+  for (std::size_t i = 0; i < seeds.size(); ++i) {
+    SeededCluster &s = seeds[i];
+    if (!s.alive)
+      continue;
+
+    // Strip search window (half-widths) around the projected impact direction.
+    const float halfDTheta = 0.5f * (s.isCharged ? m_stripDThetaCharged : m_stripDThetaNeutral);
+    const float halfDPhi   = 0.5f * (s.isCharged ? m_stripDPhiCharged   : m_stripDPhiNeutral);
+
+    // Collect candidate anchor hits inside the (theta, phi) strip, ordered by
+    // opening-angle distance to the projection so the FIRST one passing the
+    // density cut is automatically the closest qualifying anchor.
+    std::vector<const HitCache *> candidates;
+    for (const HitCache *hc : s.vicinity) {
+      if (std::fabs(hc->theta - s.thetaSeed) > halfDTheta)
+        continue;
+      if (std::fabs(VectorHelper::deltaPhi(hc->phi, s.phiSeed)) > halfDPhi)
+        continue;
+      candidates.push_back(hc);
+    }
+    std::sort(candidates.begin(), candidates.end(),
+              [&s](const HitCache *a, const HitCache *b) {
+                return VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, a->theta, a->phi) <
+                       VectorHelper::AngularDR2(s.thetaSeed, s.phiSeed, b->theta, b->phi);
+              });
+
+    // For each candidate (closest first) build its m_seedCircleRadius disk; the
+    // first whose scintillation sum passes m_rhoSeed becomes the seed circle.
+    std::vector<const HitCache *> circle;
+    bool found = false;
+    for (const HitCache *anchor : candidates) {
+      const float r_anchor = anchor->pos.GetMagnitude();
+      const float cosCut = r_anchor / std::sqrt(r_anchor * r_anchor + m_seedCircleRadius * m_seedCircleRadius);
+
+      circle.clear();
+      float scintSum = 0.f;
+      for (const HitCache *hc : s.vicinity) {
+        if (hc->energy < m_growThreshold)
+          continue;
+        if (anchor->pos.GetCosOpeningAngle(hc->pos) > cosCut) {
+          circle.push_back(hc);
+          if (!hc->isCheren)
+            scintSum += hc->energy;
+        }
+      } // loop over vicinity hits for this anchor's disk
+
+      if (scintSum >= m_rhoSeed) {
+        found = true;
+        break; // closest qualifying anchor wins
+      }
+    } // loop over strip candidates
+
+    // Kill seeds with no qualifying anchor in the strip
+    if (!found) {
+      s.alive = false;
+      continue;
+    }
+
+    circles[static_cast<int>(i)] = std::move(circle);
+  } // loop over seeds
+} // FormSeedCircles
+
+// ====================================================================== //
+//  Phase 3b - ResolveSeedCircleContests
+// ====================================================================== //
+
+void EcalSeededClusteringAlgorithm::ResolveSeedCircleContests(std::vector<SeededCluster> &seeds,
+                                                              SeedCircleMap &circles) const {
+  // Build hit -> {seed indices} map
+  std::map<const HitCache *, std::vector<int>> contestants;
+  for (const auto &[idx, circle] : circles)
+    for (const HitCache *hc : circle)
+      contestants[hc].push_back(idx);
+
+  // Resolve each contested hit with opening angle to the seed impact point
+  for (const auto &[hc, owners] : contestants) {
+    if (owners.size() < 2)
+      continue;
+
+    // Pick winner: lowest opening-angle distance
+    int   winner = owners[0];
+    float bestDist = std::numeric_limits<float>::max();
+    for (int idx : owners) {
+      if (!seeds[idx].alive)
+        continue;
+
+      const float d = OpeningAngleDist(seeds[idx].hcalImpactPoint, hc->pos);
+      if (d < bestDist) { bestDist = d; winner = idx; }
+    } // loop over contestants for this hit
+
+    // Remove from all losers
+    for (int idx : owners) {
+      if (idx == winner)
+        continue;
+
+      auto &cl = circles[idx];
+      cl.erase(std::remove(cl.begin(), cl.end(), hc), cl.end());
+
+      if (cl.empty())
+        seeds[idx].alive = false;
+    } // loop over contestants for this hit
+  } // loop over contested hits
+} // ResolveSeedCircleContests
+
+// ====================================================================== //
+//  ComputeClusterState
+// ====================================================================== //
+
+void EcalSeededClusteringAlgorithm::ComputeClusterState(ClusterState &gc) const {
+  float scintSum = 0.f, cherenSum = 0.f, totE = 0.f;
+  for (const HitCache *hc : gc.hits) {
+    totE += hc->energy;
+    if (hc->isCheren) cherenSum += hc->energy;
+    else              scintSum  += hc->energy;
+  }
+
+  gc.energy = m_useDualReadout
+      ? (scintSum - m_chiHcal * cherenSum) / (1.f - m_chiHcal)
+      : totE;
+
+  pandora::CartesianVector bary(0.f, 0.f, 0.f);
+  float totW = 0.f;
+  if (totE > 0.f) {
+    for (const HitCache *hc : gc.hits) {
+      const float w = std::max(0.f, m_w0 + std::log(hc->energy / totE));
+      if (w > 0.f) {
+        bary += hc->pos * w;
+        totW += w;
+      }
+    } // loop over hits in cluster
+  }
+
+  gc.barycenter = (totW > 0.f) ? bary * (1.f / totW)
+                                : pandora::CartesianVector(0.f, 0.f, 0.f);
+} // ComputeClusterState
+
+// ====================================================================== //
+//  Shared BFS growth engine - Grow()
+// ====================================================================== //
+
+std::vector<EcalSeededClusteringAlgorithm::ClusterState>
+EcalSeededClusteringAlgorithm::Grow(GrowStrategy strategy,
+                                    const std::vector<ClusterState> &clusters,
+                                    pandora::CaloHitSet &assignedSet) const {
+  std::vector<ClusterState> result(clusters); // working copy
+  const int n = static_cast<int>(result.size());
+  if (n == 0)
+    return {};
+
+  const float adjCut = m_adjacencyRadius; // interpreted as physical distance for cone angle
+
+  // Per-cluster frontier: hits added in the last layer.
+  // Initialised from each cluster's seed-circle hits.
+  std::map<int, std::vector<const HitCache *>> frontier;
+  for (int i = 0; i < n; ++i)
+    frontier[i] = result[i].hits;
+
+  // Union-find bookkeeping (MergeClusters only).
+  std::vector<int> rep(n);
+  std::iota(rep.begin(), rep.end(), 0);
+  auto findRep = [&rep](int x) -> int {
+    while (rep[x] != x) { rep[x] = rep[rep[x]]; x = rep[x]; }
+    return x;
+  };
+  auto mergeReps = [&rep, &findRep](int a, int b) {
+    a = findRep(a); b = findRep(b);
+    if (a != b) rep[b] = a;
+  };
+
+  // Shared lambda: accumulate candidates from a (frontier, vicinity) pair into
+  // the candidates map, keyed by the given cluster index / representative id.
+  auto collectCandidates = [&](std::map<const HitCache *, std::vector<int>> &candidates,
+                               int id,
+                               const std::vector<const HitCache *> &front,
+                               const auto &vicinity) {
+    for (const HitCache *fhc : front) {
+      // Max opening angle for adjacency: atan2(adjCut, r_fhc)
+      const float r_fhc  = fhc->pos.GetMagnitude();
+      const float cosCut = r_fhc / std::sqrt(r_fhc * r_fhc + adjCut * adjCut);
+
+      for (const HitCache *nb : vicinity) {
+        if (assignedSet.count(nb->pHit))
+          continue;
+        if (nb->energy < m_growThreshold)
+          continue;
+        if (fhc->pos.GetCosOpeningAngle(nb->pos) > cosCut)
+          candidates[nb].push_back(id);
+      }
+    }
+  };
+
+  // Shared lambda: deduplicate a sorted-or-unsorted claimers vector in-place.
+  auto deduplicateClaimers = [](std::vector<int> &claimers) {
+    std::sort(claimers.begin(), claimers.end());
+    claimers.erase(std::unique(claimers.begin(), claimers.end()), claimers.end());
+  };
+
+  bool anyAdded = true;
+  while (anyAdded) {
+    anyAdded = false;
+
+    // ---------------------------------------------------------------- //
+    //  Collect candidates, deduplicate, assign, and build next frontier.
+    //  ResolveByDist: each cluster searches its own vicinity independently.
+    //  MergeClusters: build per-representative vicinity union, then search.
+    // ---------------------------------------------------------------- //
+    std::map<int, std::vector<const HitCache *>> nextFrontier;
+
+    if (strategy == GrowStrategy::ResolveByDist) {
+      std::map<const HitCache *, std::vector<int>> candidates;
+      for (int i = 0; i < n; ++i)
+        collectCandidates(candidates, i, frontier[i], result[i].vicinity);
+
+      for (auto &[hc, claimers] : candidates) {
+        deduplicateClaimers(claimers);
+
+        int   winner = claimers[0];
+        float bestDist = std::numeric_limits<float>::max();
+        for (int idx : claimers) {
+          const float d = OpeningAngleDist(result[idx].barycenter, hc->pos);
+          if (d < bestDist) { bestDist = d; winner = idx; }
+        }
+        assignedSet.insert(hc->pHit);
+        result[winner].hits.push_back(hc);
+        nextFrontier[winner].push_back(hc);
+        anyAdded = true;
+      } // loop over candidates
+
+      // recompute cluster states
+      for (const auto &[i, _] : nextFrontier)
+        ComputeClusterState(result[i]);
+    } else { // MergeClusters: collapse frontier and vicinity into per-representative sets
+      std::map<int, std::vector<const HitCache *>> repFront;
+      std::map<int, std::set<const HitCache *>> repVicinity;
+      for (int i = 0; i < n; ++i) {
+        const int r = findRep(i);
+        for (const HitCache *hc : frontier[i])
+          repFront[r].push_back(hc);
+        for (const HitCache *hc : result[i].vicinity)
+          repVicinity[r].insert(hc);
+      } // loop over clusters to build repFront and repVicinity
+
+      std::map<const HitCache *, std::vector<int>> candidates;
+      for (const auto &[r, fr] : repFront)
+        collectCandidates(candidates, r, fr, repVicinity[r]);
+
+      for (auto &[hc, claimers] : candidates) {
+        deduplicateClaimers(claimers);
+
+        int winner = findRep(claimers[0]);
+        for (std::size_t j = 1; j < claimers.size(); ++j)
+          mergeReps(winner, claimers[j]);
+        const int ri = findRep(winner);
+        assignedSet.insert(hc->pHit);
+        result[ri].hits.push_back(hc);
+        nextFrontier[ri].push_back(hc);
+        anyAdded = true;
+      } // loop over candidates
+    } // if ResolveByDist vs. MergeClusters
+
+    frontier = std::move(nextFrontier);
+  } // while anyAdded
+
+  // MergeClusters: fold non-representative clusters into their root
+  // (hits + vicinity), then erase the now-empty entries.
+  if (strategy == GrowStrategy::MergeClusters) {
+    for (int i = 0; i < n; ++i) {
+      const int r = findRep(i);
+      if (r == i)
+        continue;
+
+      // Merge hits and vicinity into representative cluster
+      for (const HitCache *hc : result[i].hits)
+        result[r].hits.push_back(hc);
+      for (const HitCache *hc : result[i].vicinity)
+        result[r].vicinity.push_back(hc);
+
+      // Clear the non-representative cluster's hits and vicinity.
+      // Do NOT erase here — erasing inside the loop invalidates indices.
+      result[i].hits.clear();
+      result[i].vicinity.clear();
+    } // loop over clusters to merge into representatives
+
+    // Single erase pass after the loop: remove all now-empty non-representatives.
+    result.erase(
+        std::remove_if(result.begin(), result.end(),
+                       [](const ClusterState &gc) { return gc.hits.empty(); }),
+        result.end());
+  } // if MergeClusters
+
+  return result;
+} // Grow
+
+// ====================================================================== //
+//  Phases 2–4 - FormSeededClusters
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::FormSeededClusters(std::vector<SeededCluster> &seeds,
+                                                                      const std::vector<HitCache> &hcalPool,
+                                                                      pandora::CaloHitSet &assignedSet) const {
+  // ---- Phase 2a: project seeds onto HCAL surface ----
+  for (auto &s : seeds) {
+    if (ExtrapolateToHcalSurface(s) != pandora::STATUS_CODE_SUCCESS)
+      s.alive = false;
+  }
+
+  // ---- Phase 2b: per-seed vicinity pools ----
+  BuildVicinities(seeds, hcalPool);
+
+  // ---- Phase 3: seed circles + contest ----
+  SeedCircleMap circles;
+  FormSeedCircles(seeds, circles);
+  ResolveSeedCircleContests(seeds, circles);
+
+  // ---- Phase 4: BFS growth via shared Grow() ----
+  // Single pass: initialise ClusterStates from post-contest circles,
+  // mark circle hits as assigned, and copy each seed's vicinity.
+  std::vector<int> aliveIdx; // map initStates index -> seeds index
+  std::vector<ClusterState> initStates;
+
+  for (int i = 0; i < static_cast<int>(seeds.size()); ++i) {
+    if (!seeds[i].alive)
+      continue;
+    aliveIdx.push_back(i);
+
+    ClusterState cs;
+    cs.hits     = circles[i];       // HitCache* directly - no map lookup needed
+    cs.vicinity = seeds[i].vicinity; // search space for this seed
+    for (const HitCache *hc : cs.hits)
+      assignedSet.insert(hc->pHit);
+
+    ComputeClusterState(cs);
+    initStates.push_back(std::move(cs));
+  } // loop over alive seeds
+
+  const auto grown = Grow(GrowStrategy::ResolveByDist, initStates, assignedSet);
+
+  // Write grown state back into each SeededCluster (inherits ClusterState).
+  for (int j = 0; j < static_cast<int>(aliveIdx.size()); ++j) {
+    auto &s = seeds[aliveIdx[j]];
+    s.hits = grown[j].hits;
+    ComputeClusterState(s);
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // FormSeededClusters
+
+// ====================================================================== //
+//  Phase 5 - FormUnseededClusters
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::FormUnseededClusters(std::vector<UnseededCluster> &unseeded,
+                                                                        const std::vector<HitCache> &hcalPool,
+                                                                        pandora::CaloHitSet &assignedSet) const {
+  // Collect remaining HCAL hits not consumed by Phase 4.
+  std::vector<const HitCache *> remaining;
+  remaining.reserve(hcalPool.size());
+  for (const auto &hc : hcalPool) {
+    if (!assignedSet.count(hc.pHit))
+      remaining.push_back(&hc);
+  }
+
+  if (remaining.empty()) // nothing to do
+    return pandora::STATUS_CODE_SUCCESS;
+
+  // Sort by descending energy for reproducible seeding order.
+  std::sort(remaining.begin(), remaining.end(),
+            [](const HitCache *a, const HitCache *b) { return a->energy > b->energy; });
+
+  // ------------------------------------------------------------------ //
+  //  Step A: find candidate seed centers - local scint circle sum >= rhoUnseeded.
+  //  Circle hits are claimed greedily in energy order to avoid overlap.
+  // ------------------------------------------------------------------ //
+  pandora::CaloHitSet circleAssigned; // hits already claimed by a seed circle
+  std::vector<ClusterState> initStates;
+  const float maxDR2 = m_maxSearchDeltaR * m_maxSearchDeltaR;
+
+  for (const HitCache *center : remaining) {
+    // Max opening angles for this center hit: atan2(cut, r_center)
+    const float r_center   = center->pos.GetMagnitude();
+    const float cosSeedCut = r_center / std::sqrt(r_center * r_center + m_seedCircleRadius * m_seedCircleRadius);
+
+    float scintSum = 0.f;
+    ClusterState gc;
+    for (const HitCache *nb : remaining) {
+      const float dr2 = VectorHelper::AngularDR2(center->theta, center->phi, nb->theta, nb->phi);
+
+      // Vicinity: all hits in range, regardless of threshold or circle ownership
+      if (dr2 < maxDR2)
+        gc.vicinity.push_back(nb);
+
+      // Seed circle: above threshold and within seedCircleRadius, not already claimed
+      if (circleAssigned.count(nb->pHit))
+        continue;
+      if (nb->energy < m_growThreshold)
+        continue;
+
+      const float cosA = center->pos.GetCosOpeningAngle(nb->pos);
+      // form seed circle candidate
+      if (cosA > cosSeedCut) {
+        if (!nb->isCheren)
+          scintSum += nb->energy;
+
+        gc.hits.push_back(nb);
+      }
+    } // 2nd loop over remaining hits
+
+    if (scintSum < m_rhoUnseeded)
+      continue;
+
+    for (const HitCache *hc : gc.hits)
+      circleAssigned.insert(hc->pHit);
+
+    ComputeClusterState(gc);
+    initStates.push_back(std::move(gc));
+  } // 1st loop over remaining hits
+
+  if (initStates.empty())
+    return pandora::STATUS_CODE_SUCCESS;
+
+  // ------------------------------------------------------------------ //
+  //  BFS with merge-on-contest via shared Grow().
+  //  Pre-assign circle hits so Grow() won't re-claim them.
+  // ------------------------------------------------------------------ //
+  for (const auto &gc : initStates)
+    for (const HitCache *hc : gc.hits)
+      assignedSet.insert(hc->pHit);
+
+  auto result = Grow(GrowStrategy::MergeClusters, initStates, assignedSet);
+
+  // Emit one UnseededCluster per surviving root.
+  for (auto &gc : result) {
+    if (gc.hits.empty())
+      continue;
+
+    UnseededCluster u;
+    u.hits = std::move(gc.hits);
+    ComputeClusterState(u);
+    unseeded.push_back(std::move(u));
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // FormUnseededClusters
+
+// ====================================================================== //
+//  Phase 6 - WriteBack
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::WriteBack(std::vector<SeededCluster> &seeds,
+                                                             std::vector<UnseededCluster> &unseeded) const {
+  // Extend each surviving ECAL cluster with its HCAL hits
+  for (auto &s : seeds) {
+    if (!s.alive || s.hits.empty())
+      continue;
+
+    for (const HitCache *hc : s.hits) {
+      PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+          PandoraContentApi::AddToCluster(*this, s.pEcalCluster, hc->pHit));
+    }
+  }
+
+  // Get current list name before proceeding
+  std::string inputClusterListName;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentListName<pandora::Cluster>(*this, inputClusterListName));
+
+  // Recreate cluster list within the pandora framework
+  // (this will allow creating new objects)
+  const pandora::ClusterList* pClusterList = nullptr;
+  std::string clusterListName = m_outputClusterListName + "Tmp";
+
+  PANDORA_RETURN_RESULT_IF(
+      pandora::STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListName));
+
+  // Create new clusters for unseeded HCAL clusters
+  for (auto &u : unseeded) {
+    pandora::CaloHitList hitList;
+    for (const HitCache *hc : u.hits)
+      hitList.push_back(hc->pHit);
+
+    const pandora::Cluster *pNewCluster = nullptr;
+    PandoraContentApi::Cluster::Parameters params;
+    params.m_caloHitList = hitList;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::Cluster::Create(*this, params, pNewCluster));
+  }
+
+  // need these to store the pandora cluster list
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // save the previous list to the new output (seeded clusters)
+                            PandoraContentApi::SaveList<pandora::Cluster>(*this, inputClusterListName, m_outputClusterListName));
+
+  if (!unseeded.empty()) { // only replace the current list if we actually created new clusters
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // save the current list to the new output (unseeded clusters)
+                              PandoraContentApi::SaveList<pandora::Cluster>(*this, m_outputClusterListName));
+  }
+
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, // make the new output the current list
+                            PandoraContentApi::ReplaceCurrentList<pandora::Cluster>(*this, m_outputClusterListName));
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+// ====================================================================== //
+//  Helper functions
+// ====================================================================== //
+
+float EcalSeededClusteringAlgorithm::OpeningAngleDist(const pandora::CartesianVector &clusDir,
+                                                      const pandora::CartesianVector &hitPos) const {
+  const float r_hit  = hitPos.GetMagnitude();
+  const float r_clus = clusDir.GetMagnitude();
+  if (r_hit <= 0.f || r_clus <= 0.f)
+    return std::numeric_limits<float>::max();
+
+  float cosA = clusDir.GetCosOpeningAngle(hitPos);
+  cosA = std::max(-1.f, std::min(1.f, cosA));
+  return 1.f - cosA;
+} // OpeningAngleDist
+
+bool EcalSeededClusteringAlgorithm::IsHcalHit(const pandora::CaloHit *h) const {
+  return h->GetHadronicEnergy() > 0.f;
+}
+
+bool EcalSeededClusteringAlgorithm::IsCherenkovHit(const pandora::CaloHit *h) const {
+  return h->GetHitType() == pandora::DRC_CHEREN;
+}
+
+// ====================================================================== //
+//  ReadHcalGeometry
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::ReadHcalGeometry() {
+  const pandora::GeometryManager *const pGeometry = PandoraContentApi::GetGeometry(*this);
+
+  if (!pGeometry)
+    return pandora::STATUS_CODE_NOT_INITIALIZED;
+
+  // GetSubDetector throws StatusCodeException(NOT_FOUND) if the sub-detector was never registered;
+  // the algorithm manager catches it around ReadSettings and reports it.
+  m_hcalSurfaceR = pGeometry->GetSubDetector(pandora::HCAL_BARREL).GetInnerRCoordinate();
+
+  // A barrel-only geometry registers no HCAL endcap.  That is a valid configuration, not an error:
+  // the z half-length is then effectively infinite, so every direction lands on the barrel.
+  try {
+    m_hcalSurfaceZHalf = pGeometry->GetSubDetector(pandora::HCAL_ENDCAP).GetInnerZCoordinate();
+  } catch (const pandora::StatusCodeException &) {
+    m_hasHcalEndcap    = false;
+    m_hcalSurfaceZHalf = std::numeric_limits<float>::max();
+  }
+
+  if ((m_hcalSurfaceR <= 0.f) || (m_hcalSurfaceZHalf <= 0.f))
+    return pandora::STATUS_CODE_INVALID_PARAMETER;
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+// ====================================================================== //
+//  ReadSettings
+// ====================================================================== //
+
+pandora::StatusCode EcalSeededClusteringAlgorithm::ReadSettings(
+    const pandora::TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "OutputClusterListName", m_outputClusterListName));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "UseDualReadout", m_useDualReadout));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "MomentumThreshold", m_pThres));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "HardThreshold", m_hardThreshold));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "GrowThreshold", m_growThreshold));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "MaxSearchDR", m_maxSearchDeltaR));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "SeedCircleR", m_seedCircleRadius));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaCharged", m_stripDThetaCharged));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiCharged", m_stripDPhiCharged));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "StripDThetaNeutral", m_stripDThetaNeutral));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "StripDPhiNeutral", m_stripDPhiNeutral));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "AdjacencyR", m_adjacencyRadius));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "SeedThreshold", m_rhoSeed));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "UnseededThreshold", m_rhoUnseeded));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "ChargedEcalOverPMax", m_chargedEcalOverPMax));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "UseBfieldAtIP", m_useBFieldAtIP));
+
+  // The HCAL inner surface comes from the detector geometry, not from XML.
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->ReadHcalGeometry());
+
+  if (m_useDualReadout) {
+    if (m_chiHcal >= 1.f || m_chiHcal <= 0.f) {
+      std::cerr << "EcalSeededClusteringAlgorithm::ReadSettings: ChiHcal must be 0 < chi < 1";
+      std::cerr << " to avoid singularity in dual-readout correction." << std::endl;
+
+      return pandora::STATUS_CODE_INVALID_PARAMETER;
+    }
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content

--- a/src/LCHelpers/SortingHelper.cc
+++ b/src/LCHelpers/SortingHelper.cc
@@ -83,4 +83,17 @@ bool SortingHelper::SortPfosByEnergy(const ParticleFlowObject* const pLhs, const
   return (pLhs->GetEnergy() > pRhs->GetEnergy());
 }
 
+bool SortingHelper::SortTracksByDistance(const pandora::Track* a,
+                                         const pandora::Track* b,
+                                         const pandora::Cluster* const pCluster)
+{
+    const auto& trkStateA = a->GetTrackStateAtCalorimeter();
+    const auto& trkStateB = b->GetTrackStateAtCalorimeter();
+    const auto& clusterPos = pCluster->GetCentroid( pCluster->GetInnerPseudoLayer() );
+    const double distA2 = (clusterPos - trkStateA.GetPosition()).GetMagnitudeSquared();
+    const double distB2 = (clusterPos - trkStateB.GetPosition()).GetMagnitudeSquared();
+
+    return distA2 < distB2;
+}
+
 } // namespace lc_content

--- a/src/LCHelpers/SortingHelper.cc
+++ b/src/LCHelpers/SortingHelper.cc
@@ -83,17 +83,15 @@ bool SortingHelper::SortPfosByEnergy(const ParticleFlowObject* const pLhs, const
   return (pLhs->GetEnergy() > pRhs->GetEnergy());
 }
 
-bool SortingHelper::SortTracksByDistance(const pandora::Track* a,
-                                         const pandora::Track* b,
-                                         const pandora::Cluster* const pCluster)
-{
-    const auto& trkStateA = a->GetTrackStateAtCalorimeter();
-    const auto& trkStateB = b->GetTrackStateAtCalorimeter();
-    const auto& clusterPos = pCluster->GetCentroid( pCluster->GetInnerPseudoLayer() );
-    const double distA2 = (clusterPos - trkStateA.GetPosition()).GetMagnitudeSquared();
-    const double distB2 = (clusterPos - trkStateB.GetPosition()).GetMagnitudeSquared();
+bool SortingHelper::SortTracksByDistance(const pandora::Track* a, const pandora::Track* b,
+                                         const pandora::Cluster* const pCluster) {
+  const auto& trkStateA = a->GetTrackStateAtCalorimeter();
+  const auto& trkStateB = b->GetTrackStateAtCalorimeter();
+  const auto& clusterPos = pCluster->GetCentroid(pCluster->GetInnerPseudoLayer());
+  const double distA2 = (clusterPos - trkStateA.GetPosition()).GetMagnitudeSquared();
+  const double distB2 = (clusterPos - trkStateB.GetPosition()).GetMagnitudeSquared();
 
-    return distA2 < distB2;
+  return distA2 < distB2;
 }
 
 } // namespace lc_content

--- a/src/LCParticleId/ForwardPhotonIdAlgorithm.cc
+++ b/src/LCParticleId/ForwardPhotonIdAlgorithm.cc
@@ -15,18 +15,17 @@ namespace lc_content {
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ForwardPhotonIdAlgorithm::CollectHcalHits(const Cluster *const pCluster,
-                                               std::vector<HcalHit> &hits, float &eTotal) const {
+bool ForwardPhotonIdAlgorithm::CollectHcalHits(const Cluster* const pCluster, std::vector<HcalHit>& hits,
+                                               float& eTotal) const {
   hits.clear();
   eTotal = 0.f;
-  for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
-    for (const CaloHit *const pHit : *layerEntry.second) {
+  for (const auto& layerEntry : pCluster->GetOrderedCaloHitList()) {
+    for (const CaloHit* const pHit : *layerEntry.second) {
       const float eHad = pHit->GetHadronicEnergy();
-      if (eHad <= 0.f)                       // ECAL hit -> cluster is not HCAL-only
+      if (eHad <= 0.f) // ECAL hit -> cluster is not HCAL-only
         return false;
-      const CartesianVector &p = pHit->GetPositionVector();
-      hits.push_back({p.GetX(), p.GetY(), p.GetZ(), eHad,
-                      pHit->GetHitType() == DRC_CHEREN});
+      const CartesianVector& p = pHit->GetPositionVector();
+      hits.push_back({p.GetX(), p.GetY(), p.GetZ(), eHad, pHit->GetHitType() == DRC_CHEREN});
       eTotal += eHad;
     }
   }
@@ -35,44 +34,55 @@ bool ForwardPhotonIdAlgorithm::CollectHcalHits(const Cluster *const pCluster,
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ForwardPhotonIdAlgorithm::W0Centroid(const std::vector<HcalHit> &hits, const float eTotal,
-                                          CartesianVector &centroid) const {
+bool ForwardPhotonIdAlgorithm::W0Centroid(const std::vector<HcalHit>& hits, const float eTotal,
+                                          CartesianVector& centroid) const {
   double sx = 0., sy = 0., sz = 0., sw = 0.;
-  for (const HcalHit &h : hits) {
+  for (const HcalHit& h : hits) {
     const float w = m_w0 + std::log(h.e / eTotal);
-    if (w <= 0.f) continue;
-    sx += h.x * w; sy += h.y * w; sz += h.z * w; sw += w;
+    if (w <= 0.f)
+      continue;
+    sx += h.x * w;
+    sy += h.y * w;
+    sz += h.z * w;
+    sw += w;
   }
   if (sw <= 0.)
     return false;
-  centroid = CartesianVector(static_cast<float>(sx / sw),
-                             static_cast<float>(sy / sw),
-                             static_cast<float>(sz / sw));
+  centroid = CartesianVector(static_cast<float>(sx / sw), static_cast<float>(sy / sw), static_cast<float>(sz / sw));
   return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ForwardPhotonIdAlgorithm::CherToScintRatio(const std::vector<HcalHit> &hits) const {
+float ForwardPhotonIdAlgorithm::CherToScintRatio(const std::vector<HcalHit>& hits) const {
   float S = 0.f, C = 0.f;
-  for (const HcalHit &h : hits) { if (h.isCher) C += h.e; else S += h.e; }
+  for (const HcalHit& h : hits) {
+    if (h.isCher)
+      C += h.e;
+    else
+      S += h.e;
+  }
   if (S <= 0.f)
-    return -1.f;                             // S == 0 -> skip (per design)
+    return -1.f; // S == 0 -> skip (per design)
   return C / S;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ForwardPhotonIdAlgorithm::DRcorrHcal(const std::vector<HcalHit> &hits) const {
+float ForwardPhotonIdAlgorithm::DRcorrHcal(const std::vector<HcalHit>& hits) const {
   float S = 0.f, C = 0.f;
-  for (const HcalHit &h : hits) { if (h.isCher) C += h.e; else S += h.e; }
+  for (const HcalHit& h : hits) {
+    if (h.isCher)
+      C += h.e;
+    else
+      S += h.e;
+  }
   return (S > 0.f && C > 0.f) ? (S - m_chiHcal * C) / (1.f - m_chiHcal) : S;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ForwardPhotonIdAlgorithm::CoreFraction(const std::vector<HcalHit> &hits,
-                                             const CartesianVector &centroid,
+float ForwardPhotonIdAlgorithm::CoreFraction(const std::vector<HcalHit>& hits, const CartesianVector& centroid,
                                              const float rCentroid) const {
   const float eDrTotal = this->DRcorrHcal(hits);
   if (eDrTotal <= 0.f)
@@ -81,9 +91,9 @@ float ForwardPhotonIdAlgorithm::CoreFraction(const std::vector<HcalHit> &hits,
   const float ux = u.GetX(), uy = u.GetY(), uz = u.GetZ();
   const float cosCone = std::cos(std::atan(m_coreMm / rCentroid));
   std::vector<HcalHit> coreHits;
-  for (const HcalHit &h : hits) {
-    const float rh = std::sqrt(h.x*h.x + h.y*h.y + h.z*h.z);
-    if (rh > 0.f && (ux*h.x + uy*h.y + uz*h.z) / rh > cosCone)
+  for (const HcalHit& h : hits) {
+    const float rh = std::sqrt(h.x * h.x + h.y * h.y + h.z * h.z);
+    if (rh > 0.f && (ux * h.x + uy * h.y + uz * h.z) / rh > cosCone)
       coreHits.push_back(h);
   }
   return this->DRcorrHcal(coreHits) / eDrTotal;
@@ -92,19 +102,18 @@ float ForwardPhotonIdAlgorithm::CoreFraction(const std::vector<HcalHit> &hits,
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ForwardPhotonIdAlgorithm::Run() {
-  const ClusterList *pClusterList = nullptr;
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::GetCurrentList(*this, pClusterList));
+  const ClusterList* pClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
 
-  for (const Cluster *const pCluster : *pClusterList) {
+  for (const Cluster* const pCluster : *pClusterList) {
     if (!pCluster->IsAvailable())
       continue;
     if (!pCluster->GetAssociatedTrackList().empty())
-      continue;                              // charged -> not a candidate
+      continue; // charged -> not a candidate
 
     const int particleId = pCluster->GetParticleId();
     if (PHOTON == particleId || K_LONG == particleId)
-      continue;                              // already identified -> leave alone
+      continue; // already identified -> leave alone
 
     // ---- HCAL-only hit collection (also yields the total energy) ----
     std::vector<HcalHit> hcalHits;
@@ -122,8 +131,7 @@ StatusCode ForwardPhotonIdAlgorithm::Run() {
       continue;
 
     // ---- cut 0 (cheap, rejects most clusters): forward  |eta| > MinAbsEta ----
-    const float th  = std::min(std::max(thetaC, 1e-6f),
-                               static_cast<float>(M_PI) - 1e-6f);
+    const float th = std::min(std::max(thetaC, 1e-6f), static_cast<float>(M_PI) - 1e-6f);
     const float eta = -std::log(std::tan(0.5f * th));
     if (std::fabs(eta) <= m_minAbsEta)
       continue;
@@ -141,7 +149,7 @@ StatusCode ForwardPhotonIdAlgorithm::Run() {
     PandoraContentApi::Cluster::Metadata metadata;
     metadata.m_particleId = PHOTON;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-        PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
+                             PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
   }
 
   return STATUS_CODE_SUCCESS;
@@ -151,17 +159,17 @@ StatusCode ForwardPhotonIdAlgorithm::Run() {
 
 StatusCode ForwardPhotonIdAlgorithm::ReadSettings(const TiXmlHandle xmlHandle) {
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "MinCS", m_minCS));
+                                  XmlHelper::ReadValue(xmlHandle, "MinCS", m_minCS));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "MinAbsEta", m_minAbsEta));
+                                  XmlHelper::ReadValue(xmlHandle, "MinAbsEta", m_minAbsEta));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "CoreMm", m_coreMm));
+                                  XmlHelper::ReadValue(xmlHandle, "CoreMm", m_coreMm));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "MinCoreFraction", m_minCoreFrac));
+                                  XmlHelper::ReadValue(xmlHandle, "MinCoreFraction", m_minCoreFrac));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+                                  XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
+                                  XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
   return STATUS_CODE_SUCCESS;
 }
 

--- a/src/LCParticleId/ForwardPhotonIdAlgorithm.cc
+++ b/src/LCParticleId/ForwardPhotonIdAlgorithm.cc
@@ -1,0 +1,168 @@
+/**
+ *  @file   LCContent/src/LCParticleId/ForwardPhotonIdAlgorithm.cc
+ *
+ *  @brief  Implementation of the cut-based forward-photon tagging algorithm.
+ */
+#include "LCParticleId/ForwardPhotonIdAlgorithm.h"
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include <cmath>
+
+using namespace pandora;
+
+namespace lc_content {
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool ForwardPhotonIdAlgorithm::CollectHcalHits(const Cluster *const pCluster,
+                                               std::vector<HcalHit> &hits, float &eTotal) const {
+  hits.clear();
+  eTotal = 0.f;
+  for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
+    for (const CaloHit *const pHit : *layerEntry.second) {
+      const float eHad = pHit->GetHadronicEnergy();
+      if (eHad <= 0.f)                       // ECAL hit -> cluster is not HCAL-only
+        return false;
+      const CartesianVector &p = pHit->GetPositionVector();
+      hits.push_back({p.GetX(), p.GetY(), p.GetZ(), eHad,
+                      pHit->GetHitType() == DRC_CHEREN});
+      eTotal += eHad;
+    }
+  }
+  return (!hits.empty() && eTotal > 0.f);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool ForwardPhotonIdAlgorithm::W0Centroid(const std::vector<HcalHit> &hits, const float eTotal,
+                                          CartesianVector &centroid) const {
+  double sx = 0., sy = 0., sz = 0., sw = 0.;
+  for (const HcalHit &h : hits) {
+    const float w = m_w0 + std::log(h.e / eTotal);
+    if (w <= 0.f) continue;
+    sx += h.x * w; sy += h.y * w; sz += h.z * w; sw += w;
+  }
+  if (sw <= 0.)
+    return false;
+  centroid = CartesianVector(static_cast<float>(sx / sw),
+                             static_cast<float>(sy / sw),
+                             static_cast<float>(sz / sw));
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ForwardPhotonIdAlgorithm::CherToScintRatio(const std::vector<HcalHit> &hits) const {
+  float S = 0.f, C = 0.f;
+  for (const HcalHit &h : hits) { if (h.isCher) C += h.e; else S += h.e; }
+  if (S <= 0.f)
+    return -1.f;                             // S == 0 -> skip (per design)
+  return C / S;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ForwardPhotonIdAlgorithm::DRcorrHcal(const std::vector<HcalHit> &hits) const {
+  float S = 0.f, C = 0.f;
+  for (const HcalHit &h : hits) { if (h.isCher) C += h.e; else S += h.e; }
+  return (S > 0.f && C > 0.f) ? (S - m_chiHcal * C) / (1.f - m_chiHcal) : S;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ForwardPhotonIdAlgorithm::CoreFraction(const std::vector<HcalHit> &hits,
+                                             const CartesianVector &centroid,
+                                             const float rCentroid) const {
+  const float eDrTotal = this->DRcorrHcal(hits);
+  if (eDrTotal <= 0.f)
+    return 0.f;
+  const CartesianVector u = centroid.GetUnitVector();
+  const float ux = u.GetX(), uy = u.GetY(), uz = u.GetZ();
+  const float cosCone = std::cos(std::atan(m_coreMm / rCentroid));
+  std::vector<HcalHit> coreHits;
+  for (const HcalHit &h : hits) {
+    const float rh = std::sqrt(h.x*h.x + h.y*h.y + h.z*h.z);
+    if (rh > 0.f && (ux*h.x + uy*h.y + uz*h.z) / rh > cosCone)
+      coreHits.push_back(h);
+  }
+  return this->DRcorrHcal(coreHits) / eDrTotal;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ForwardPhotonIdAlgorithm::Run() {
+  const ClusterList *pClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentList(*this, pClusterList));
+
+  for (const Cluster *const pCluster : *pClusterList) {
+    if (!pCluster->IsAvailable())
+      continue;
+    if (!pCluster->GetAssociatedTrackList().empty())
+      continue;                              // charged -> not a candidate
+
+    const int particleId = pCluster->GetParticleId();
+    if (PHOTON == particleId || K_LONG == particleId)
+      continue;                              // already identified -> leave alone
+
+    // ---- HCAL-only hit collection (also yields the total energy) ----
+    std::vector<HcalHit> hcalHits;
+    float eTotal = 0.f;
+    if (!this->CollectHcalHits(pCluster, hcalHits, eTotal))
+      continue;
+
+    // ---- W0 log-weighted centroid ----
+    CartesianVector centroid(0.f, 0.f, 0.f);
+    if (!this->W0Centroid(hcalHits, eTotal, centroid))
+      continue;
+    float rC, phiC, thetaC;
+    centroid.GetSphericalCoordinates(rC, phiC, thetaC);
+    if (rC <= 0.f)
+      continue;
+
+    // ---- cut 0 (cheap, rejects most clusters): forward  |eta| > MinAbsEta ----
+    const float th  = std::min(std::max(thetaC, 1e-6f),
+                               static_cast<float>(M_PI) - 1e-6f);
+    const float eta = -std::log(std::tan(0.5f * th));
+    if (std::fabs(eta) <= m_minAbsEta)
+      continue;
+
+    // ---- cut 1: Cherenkov-richness  C/S > MinCS  (S == 0 -> skip) ----
+    const float cs = this->CherToScintRatio(hcalHits);
+    if (cs <= m_minCS)
+      continue;
+
+    // ---- cut 2: lateral compactness  coreFraction > MinCoreFraction ----
+    if (this->CoreFraction(hcalHits, centroid, rC) <= m_minCoreFrac)
+      continue;
+
+    // ---- all cuts passed: tag as photon ----
+    PandoraContentApi::Cluster::Metadata metadata;
+    metadata.m_particleId = PHOTON;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
+  }
+
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ForwardPhotonIdAlgorithm::ReadSettings(const TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "MinCS", m_minCS));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "MinAbsEta", m_minAbsEta));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "CoreMm", m_coreMm));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "MinCoreFraction", m_minCoreFrac));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
+  return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content

--- a/src/LCPfoConstruction/IdeaPfoCreationAlgorithm.cc
+++ b/src/LCPfoConstruction/IdeaPfoCreationAlgorithm.cc
@@ -1,0 +1,488 @@
+#include "LCPfoConstruction/IdeaPfoCreationAlgorithm.h"
+#include "LCHelpers/SortingHelper.h"
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Pandora/PdgTable.h"
+
+#include "LCHelpers/VectorHelper.h"
+
+#include <cmath>          // std::cos
+#include <algorithm>      // std::min / std::max
+#include <limits>         // std::numeric_limits
+#include <unordered_map>  // regional cache
+
+namespace lc_content {
+
+IdeaPfoCreationAlgorithm::IdeaPfoCreationAlgorithm() {}
+
+const pandora::Track* IdeaPfoCreationAlgorithm::FindBestAssociatedTrack(const pandora::Cluster* aClus) const {
+  const auto& associatedTrackList = aClus->GetAssociatedTrackList();
+
+  if (associatedTrackList.empty())
+    return nullptr;
+
+  auto sortByTrackClusterDistance = [&aClus](const pandora::Track* a, const pandora::Track* b) {
+    return SortingHelper::SortTracksByDistance(a,b,aClus);
+  };
+
+  std::vector<const pandora::Track*> tracksVector;
+  tracksVector.insert(tracksVector.end(),
+                      associatedTrackList.begin(),
+                      associatedTrackList.end());
+
+  std::sort(tracksVector.begin(),tracksVector.end(),sortByTrackClusterDistance);
+
+  return tracksVector.front();
+} // FindBestAssociatedTrack
+
+float IdeaPfoCreationAlgorithm::EstimateScintEnergy(const pandora::Cluster* aClus) const {
+  // E_S = ecalS + hcalS: scintillation sum with the same accumulation as the dual-readout plugin
+  // (ECAL scint at EM scale, HCAL scint at hadronic scale), isolated hits included.
+  pandora::CaloHitList hits;
+  aClus->GetOrderedCaloHitList().FillCaloHitList(hits);
+  const auto& isolated = aClus->GetIsolatedCaloHitList();
+
+  float eS = 0.f;
+  for (const pandora::CaloHitList& hitList : {hits, isolated}) {
+    for (const auto* hit : hitList) {
+      if (hit->GetHitType() != pandora::DRC_SCINT)
+        continue;
+      const float em = hit->GetElectromagneticEnergy();  // > 0 for ECAL
+      eS += (em > 0.f) ? em : hit->GetHadronicEnergy();   // else HCAL scint (hadronic scale)
+    }
+  }
+
+  return eS;
+} // EstimateScintEnergy
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::GetDualReadoutEnergy(const pandora::Cluster* aClus, float& energy) const {
+  const auto* pEnergyCorrections = PandoraContentApi::GetPlugins(*this)->GetEnergyCorrections();
+
+  if (!pEnergyCorrections) {
+    std::cerr << "IdeaPfoCreationAlgorithm: Unable to retrieve EnergyCorrections plugin!" << std::endl;
+    return pandora::STATUS_CODE_FAILURE;
+  }
+
+  float correctedEm = 0.f, correctedHad = 0.f;
+  pEnergyCorrections->MakeEnergyCorrections(aClus, correctedEm, correctedHad);
+  energy = correctedHad; // use hadronic (dual-readout corrected) energy
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // GetDualReadoutEnergy
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::IsEmShower(const pandora::Cluster* aClus, bool& isEmShower) const {
+  const auto* pParticleId = PandoraContentApi::GetPlugins(*this)->GetParticleId();
+
+  if (!pParticleId) {
+    std::cerr << "IdeaPfoCreationAlgorithm: Unable to retrieve ParticleId plugin!" << std::endl;
+    return pandora::STATUS_CODE_FAILURE;
+  }
+
+  isEmShower = pParticleId->IsEmShower(aClus);
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // IsEmShower
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::Run() {
+  const pandora::PfoList* pPfoList = nullptr;
+  std::string pfoListName;
+
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
+
+  // for now rely on the "Calo-driven" way
+  pandora::ClusterList chargedClusters, neutralClusters;
+
+  const pandora::ClusterList* clusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, clusterList));
+
+  for (auto iter = clusterList->begin(); iter != clusterList->end(); ++ iter) {
+    const pandora::Cluster* const aClus = *iter;
+    const auto& associatedTrackList = aClus->GetAssociatedTrackList();
+
+    if (!associatedTrackList.empty()) {
+      chargedClusters.push_back(aClus);
+    } else {
+      neutralClusters.push_back(aClus);
+    }
+  }
+
+  // retrieve PID plugins
+  // const auto* pParticleId = PandoraContentApi::GetPlugins(*this)->GetParticleId();
+
+  // if (!pParticleId) {
+  //   std::cerr << "IdeaPfoCreationAlgorithm: Unable to retrieve ParticleId plugin!" << std::endl;
+  //   return pandora::STATUS_CODE_FAILURE;
+  // }
+
+  // fetch the track list up front (needed by CreatePfoFromTrack)
+  const pandora::TrackList* trackList = nullptr;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, trackList));
+
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreateElectronCandidates(chargedClusters));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreateChargedHadronCandidates(chargedClusters));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreatePhotonCandidates(neutralClusters));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreateNeutralHadronCandidates(neutralClusters));
+
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreatePfoFromTrack(trackList));
+
+  if (!pPfoList->empty()) {
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // Run
+
+float IdeaPfoCreationAlgorithm::CaloSigma(float p, bool isEm) const {
+  if (p <= 0.f)
+    return std::numeric_limits<float>::max();
+
+  const float stoch = isEm ? m_stochasticEm : m_stochasticHad;
+  const float cst   = isEm ? m_constantEm   : m_constantHad;
+  return std::max(m_sigmaFloor, stoch / std::sqrt(p) + cst);
+}
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::CreateElectronCandidates(const pandora::ClusterList& /*clusterList*/) const {
+  // No electron ID yet -> all track-associated clusters are handled by the charged-hadron branch
+  // (electrons inside jets are rare).  Disabled (not removed): original body commented out below.
+  return pandora::STATUS_CODE_SUCCESS;
+  /*
+  // loop over clusters
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+    const pandora::Cluster* const aClus = *iter;
+
+    bool isEmShower = aClus->GetParticleId() == pandora::PHOTON; // use photon flag set upstream for now
+    // PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->IsEmShower(aClus, isEmShower));
+
+    if (!isEmShower)
+      continue; // TODO electron ID can be different from the photon ID
+
+    const auto& associatedTrackList = aClus->GetAssociatedTrackList();
+    bool hasMutlipleTracks = associatedTrackList.size() > 1;
+
+    // create PFO
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_clusterList.push_back(aClus);
+
+    for (const auto* aTrack : associatedTrackList) {
+      // add all associated tracks for now
+      pfoParameters.m_trackList.push_back(aTrack);
+    }
+
+    const auto* bestTrack = FindBestAssociatedTrack(aClus);
+
+    // TODO apply proper electron ID and use different energy estimation for electrons
+    // use cluster property if there are multiple tracks
+    float energy = bestTrack->GetMomentumAtDca().GetMagnitude();
+    float clusterEnergy = 0.f;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->GetDualReadoutEnergy(aClus, clusterEnergy));
+    auto momentum = bestTrack->GetMomentumAtDca();
+    const float eop = clusterEnergy / energy;
+    const float sigmaEm = CaloSigma(energy, isEmShower);
+    bool failEoverP = eop > 1.f + m_nSigma * sigmaEm;
+
+    if (hasMutlipleTracks || failEoverP) {
+      // fall back to cluster energy if there are multiple tracks or fail E/p cut
+      energy = clusterEnergy;
+
+      // calculate energy and momentum
+      auto clusterPos = aClus->GetCentroid(aClus->GetInnerPseudoLayer()); // TODO use beamspot
+      auto unitVec = clusterPos.GetUnitVector();
+      momentum = unitVec * energy;
+    }
+
+    pfoParameters.m_energy = energy;
+    pfoParameters.m_momentum = momentum;
+    pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::E_MINUS);
+    pfoParameters.m_charge = bestTrack->GetCharge();
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::E_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::E_MINUS);
+
+    // TODO add vertex
+
+    // Create the pfo
+    const pandora::ParticleFlowObject* aPFO = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+  } // cluster loop
+
+  return pandora::STATUS_CODE_SUCCESS;
+  */
+} // CreateElectronCandidates
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(const pandora::ClusterList& clusterList) const {
+  // ---- regional-excess significance gate for the charged-hadron energy -------------------------------
+  //   Single-track cluster: over a 3D opening-angle cone (m_coneOpeningAngle), sum E_DR of ALL clusters
+  //   (charged + neutral) and p of all associated tracks.  Form the regional neutral excess and its
+  //   significance against the calo resolution:
+  //       S = (sumEdr - sumP) / ( sigma_c(sumEdr) * sumEdr )
+  //   S > m_significanceK : a real neutral is merged into the region -> keep the precise track p on the
+  //                         charged PFO and EMIT the FULL cluster excess (E_DR - p) as a separate
+  //                         clusterless neutral-hadron PFO along the cluster centroid (a genuine particle).
+  //   otherwise           : pure charged -> charged PFO = track p, no neutral.
+  //   The charged energy is NEVER inflated (the tracker measurement is left untouched); the recovered
+  //   neutral is always a distinct object with its physical calo-minus-track energy.
+  //   Multi-track cluster -> whole E_DR at the centroid (the per-track gate is undefined with >1 track).
+  //   Regional cache (E_DR, centroid, sum track p per cluster) is built ONCE so the cone loop never
+  //   re-loops the calo hits.  The track (IP) direction for the charged PFO is what wins the downstream
+  //   jet assignment (curling low-pT tracks: the momentum tangent at the calo points to the wrong jet).
+
+  const pandora::ClusterList* fullClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, fullClusterList));
+
+  struct RegInfo { pandora::CartesianVector dir; float edr; float sumP; };
+  std::unordered_map<const pandora::Cluster*, RegInfo> cache;
+  cache.reserve(fullClusterList->size());
+  for (const auto* c : *fullClusterList) {
+    float edr = 0.f;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->GetDualReadoutEnergy(c, edr));
+    float sumP = 0.f;
+    for (const auto* trk : c->GetAssociatedTrackList())
+      sumP += trk->GetMomentumAtDca().GetMagnitude();       // sum ALL associated tracks (not best)
+    cache.emplace(c, RegInfo{c->GetCentroid(c->GetInnerPseudoLayer()).GetUnitVector(), edr, sumP});
+  }
+
+  const float cosCone = std::cos(m_coneOpeningAngle);
+
+  // loop over the (track-associated) charged clusters and build the PFOs
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+    const pandora::Cluster* const aClus = *iter;
+
+    const auto& associatedTrackList = aClus->GetAssociatedTrackList();
+    const bool  hasMutlipleTracks = associatedTrackList.size() > 1;
+
+    // create PFO
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_clusterList.push_back(aClus);
+
+    for (const auto* aTrack : associatedTrackList) {
+      // add all associated tracks for now
+      pfoParameters.m_trackList.push_back(aTrack);
+    }
+
+    const auto* bestTrack = FindBestAssociatedTrack(aClus);
+
+    const RegInfo& self = cache.at(aClus);
+    const float clusterEnergy = self.edr;                   // this cluster's E_DR (from the cache)
+    const float trackP        = bestTrack->GetMomentumAtDca().GetMagnitude();
+
+    // regional E/p over the opening-angle cone (self included: cos = 1 > cosCone)
+    float sumEdr = 0.f, sumP = 0.f;
+    for (const auto& kv : cache) {
+      if (self.dir.GetCosOpeningAngle(kv.second.dir) > cosCone) {
+        sumEdr += kv.second.edr;
+        sumP   += kv.second.sumP;
+      }
+    }
+    const float sigmaReg  = CaloSigma(sumEdr, /*isEm=*/false);     // fractional hadronic sigma at the regional E_DR
+    const float regExcess = sumEdr - sumP;                         // regional neutral energy (calo above tracks)
+    const bool  gateFires = regExcess > m_significanceK * sigmaReg * sumEdr;   // S = regExcess/(sigma_c*sumEdr) > k
+    const float clusterExcess = clusterEnergy - trackP;           // this cluster's calo-minus-track energy
+
+    float energy       = trackP;                                  // charged PFO keeps the exact track p (never inflated)
+    auto  momentum     = bestTrack->GetMomentumAtDca();           // track (IP) momentum, magnitude p
+    float newNeutralEn = 0.f;
+
+    if (hasMutlipleTracks) {
+      energy   = clusterEnergy;                                   // multi-track -> whole E_DR at centroid
+      momentum = self.dir * energy;
+    } else if (gateFires && clusterExcess > 0.f) {
+      newNeutralEn = clusterExcess;                               // gate fires: emit the FULL excess as a real neutral
+    }
+    // else: pure charged -> energy = trackP, no neutral
+
+    pfoParameters.m_energy = energy;
+    pfoParameters.m_momentum = momentum;
+    pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::PI_PLUS); // TODO pion mass for now (revisit after K-pi separation)
+    pfoParameters.m_charge = bestTrack->GetCharge();
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::PI_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::PI_MINUS);
+
+    // TODO add vertex
+
+    // Create the charged pfo
+    const pandora::ParticleFlowObject* aPFO = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+
+    // Emitted co-axial neutral (gate fired) -> separate neutral-hadron PFO along the cluster centroid.
+    // It carries NO cluster: Pandora enforces exclusive cluster->PFO ownership (the charged PFO already
+    // owns this cluster -- sharing it throws STATUS_CODE_NOT_ALLOWED), and this neutral is an INFERRED
+    // energy from the charged cluster's calo excess with no calo of its own.  Jet reco uses its
+    // 4-momentum (energy = excess, centroid direction).
+    if (newNeutralEn > 0.f) {
+      PandoraContentApi::ParticleFlowObject::Parameters nhParams;
+      nhParams.m_energy     = newNeutralEn;
+      nhParams.m_momentum   = self.dir * newNeutralEn;
+      nhParams.m_mass       = pandora::PdgTable::GetParticleMass(pandora::K_LONG);
+      nhParams.m_charge     = 0.f;
+      nhParams.m_particleId = pandora::PdgTable::GetParticlePdgCode(pandora::K_LONG);
+      const pandora::ParticleFlowObject* nhPFO = nullptr;
+      PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+          PandoraContentApi::ParticleFlowObject::Create(*this, nhParams, nhPFO));
+    }
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // CreateChargedHadronCandidates
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePhotonCandidates(const pandora::ClusterList& clusterList) const {
+  // loop over clusters
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+    const pandora::Cluster* const aClus = *iter;
+
+    // use photon flag set upstream
+    if (aClus->GetParticleId() != pandora::PHOTON)
+      continue;
+
+    // Photon energy = E_S (scintillation only).  For EM showers S ~= C, so the dual-readout
+    // combination E_DR = (S - chi*C)/(1 - chi) only adds Cherenkov sampling noise; the plain
+    // scintillation sum E_S = ecalS + hcalS is the lower-variance photon estimator.
+    const float photonEnergy = this->EstimateScintEnergy(aClus);
+
+    auto clusterPos = aClus->GetCentroid(aClus->GetInnerPseudoLayer()); // TODO use beamspot
+    auto unitVec = clusterPos.GetUnitVector();
+    auto photonMomentum = unitVec * photonEnergy;
+
+    // create PFO
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_clusterList.push_back(aClus);
+    pfoParameters.m_energy = photonEnergy;
+    pfoParameters.m_momentum = photonMomentum;
+    pfoParameters.m_mass = 0.f;
+    pfoParameters.m_charge = 0.f;
+    pfoParameters.m_particleId = pandora::PdgTable::GetParticlePdgCode(pandora::PHOTON);
+
+    // Create the pfo
+    const pandora::ParticleFlowObject* aPFO = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // CreatePhotonCandidates
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::CreateNeutralHadronCandidates(const pandora::ClusterList& clusterList) const {
+  // loop over clusters
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+    const pandora::Cluster* const aClus = *iter;
+
+    if (aClus->GetParticleId() == pandora::PHOTON)
+      continue; // flagged as photon: skip
+
+    // run dual-readout correction for energy estimation
+    float clusterEnergy = 0.f;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->GetDualReadoutEnergy(aClus, clusterEnergy));
+
+    // Flat hadronic-response calibration on the E_DR neutral-hadron energy.  E_DR under-responds for
+    // these (mostly untracked-charged-as-neutral) hadron clusters by ~10% at the event level; the
+    // jet-energy-budget / NH-scale-scan study shows a constant 1.10 lift de-biases the di-jet mass to
+    // ~91 GeV with NO mass-resolution cost.  (The recovered-neutral K_LONG PFOs in the charged branch
+    // are regression-calibrated to the true scale, so they are NOT scaled.)  XML "NeutralHadEnergyScale".
+    clusterEnergy *= m_neutralHadScale;
+
+    // create PFO
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_clusterList.push_back(aClus);
+
+    // calculate energy and momentum
+    auto clusterPos = aClus->GetCentroid(aClus->GetInnerPseudoLayer()); // TODO use beamspot
+    auto unitVec = clusterPos.GetUnitVector();
+    auto momentum = unitVec * clusterEnergy;
+
+    pfoParameters.m_energy = clusterEnergy;
+    pfoParameters.m_momentum = momentum;
+    pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::K_LONG);
+    pfoParameters.m_charge = 0.f;
+    pfoParameters.m_particleId = aClus->GetParticleId(); // pandora::PdgTable::GetParticlePdgCode(pandora::K_LONG);
+
+    // Create the pfo
+    const pandora::ParticleFlowObject* aPFO = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // CreateNeutralHadronCandidates
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePfoFromTrack(const pandora::TrackList* /*trackList*/) const {
+  // DISABLED: clusterless track-only ("looper") PFO emission removed -- it DOUBLE-COUNTS energy.
+  // These low-pT tracks have no associated cluster, but truth shows ~91% of them DO reach the calo and
+  // deposit into CLUSTERED cells (already counted as NH/photon); the track is then added again here as a
+  // muon PFO (~0.8 GeV/evt double-count).  Root cause is a track-cluster ASSOCIATION failure: Pandora's
+  // single-helix extrapolation gives a (0,0,0) AtCalorimeter state for 58% of these curlers, and lands
+  // >15 mm off the nearest ECAL hit for most of the rest, so the ECAL 10 mm match cannot fire.  The
+  // (rejected) forward-|eta| hypothesis was 0%.  Proper fix is upstream: a real track finder + Kalman fit
+  // with material/extrapolation, then these clusters associate and become charged.  Until then, do NOT
+  // emit them.  (The co-axial-neutral K_LONG from the E_DR/p gate in the charged branch is unaffected.)
+  return pandora::STATUS_CODE_SUCCESS;
+  /*
+  const pandora::ClusterList* clusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentList(*this, clusterList));
+
+  // loop over tracks and create a PFO for each track not already used in the cluster-based PFOs
+  for (const auto* track : *trackList) {
+    if (track->HasAssociatedCluster())
+      continue;
+
+    float pt, phi, pz;
+    track->GetMomentumAtDca().GetCylindricalCoordinates(pt, phi, pz);
+
+    if (pt > m_ptCut)
+      continue; // it should have reached the calorimeter
+
+    // create PFO
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_trackList.push_back(track);
+
+    // calculate energy and momentum
+    float energy = track->GetMomentumAtDca().GetMagnitude();
+    auto momentum = track->GetMomentumAtDca();
+
+    pfoParameters.m_energy = energy;
+    pfoParameters.m_momentum = momentum;
+    pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::MU_MINUS); // muon for now
+    pfoParameters.m_charge = track->GetCharge();
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::MU_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::MU_MINUS);
+
+    // Create the pfo
+    const pandora::ParticleFlowObject* aPFO = nullptr;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+  */
+} // CreatePfoFromTrack
+
+pandora::StatusCode IdeaPfoCreationAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "OutputPfoListName", m_outputPfoListName));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "NSigma", m_nSigma));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "StochasticTermHad", m_stochasticHad));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "ConstantTermHad", m_constantHad));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "StochasticTermEm", m_stochasticEm));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "ConstantTermEm", m_constantEm));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "PtCut", m_ptCut));
+
+  // regional-excess significance gate on the charged-hadron energy
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "ConeOpeningAngle", m_coneOpeningAngle));
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "SignificanceK", m_significanceK));
+
+  // flat neutral-hadron energy calibration (independent of the regression; default 1.10)
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "NeutralHadEnergyScale", m_neutralHadScale));
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content

--- a/src/LCPfoConstruction/IdeaPfoCreationAlgorithm.cc
+++ b/src/LCPfoConstruction/IdeaPfoCreationAlgorithm.cc
@@ -6,10 +6,10 @@
 
 #include "LCHelpers/VectorHelper.h"
 
-#include <cmath>          // std::cos
-#include <algorithm>      // std::min / std::max
-#include <limits>         // std::numeric_limits
-#include <unordered_map>  // regional cache
+#include <algorithm>     // std::min / std::max
+#include <cmath>         // std::cos
+#include <limits>        // std::numeric_limits
+#include <unordered_map> // regional cache
 
 namespace lc_content {
 
@@ -22,15 +22,13 @@ const pandora::Track* IdeaPfoCreationAlgorithm::FindBestAssociatedTrack(const pa
     return nullptr;
 
   auto sortByTrackClusterDistance = [&aClus](const pandora::Track* a, const pandora::Track* b) {
-    return SortingHelper::SortTracksByDistance(a,b,aClus);
+    return SortingHelper::SortTracksByDistance(a, b, aClus);
   };
 
   std::vector<const pandora::Track*> tracksVector;
-  tracksVector.insert(tracksVector.end(),
-                      associatedTrackList.begin(),
-                      associatedTrackList.end());
+  tracksVector.insert(tracksVector.end(), associatedTrackList.begin(), associatedTrackList.end());
 
-  std::sort(tracksVector.begin(),tracksVector.end(),sortByTrackClusterDistance);
+  std::sort(tracksVector.begin(), tracksVector.end(), sortByTrackClusterDistance);
 
   return tracksVector.front();
 } // FindBestAssociatedTrack
@@ -47,8 +45,8 @@ float IdeaPfoCreationAlgorithm::EstimateScintEnergy(const pandora::Cluster* aClu
     for (const auto* hit : hitList) {
       if (hit->GetHitType() != pandora::DRC_SCINT)
         continue;
-      const float em = hit->GetElectromagneticEnergy();  // > 0 for ECAL
-      eS += (em > 0.f) ? em : hit->GetHadronicEnergy();   // else HCAL scint (hadronic scale)
+      const float em = hit->GetElectromagneticEnergy(); // > 0 for ECAL
+      eS += (em > 0.f) ? em : hit->GetHadronicEnergy(); // else HCAL scint (hadronic scale)
     }
   }
 
@@ -87,7 +85,8 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::Run() {
   const pandora::PfoList* pPfoList = nullptr;
   std::string pfoListName;
 
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
   // for now rely on the "Calo-driven" way
   pandora::ClusterList chargedClusters, neutralClusters;
@@ -95,7 +94,7 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::Run() {
   const pandora::ClusterList* clusterList = nullptr;
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, clusterList));
 
-  for (auto iter = clusterList->begin(); iter != clusterList->end(); ++ iter) {
+  for (auto iter = clusterList->begin(); iter != clusterList->end(); ++iter) {
     const pandora::Cluster* const aClus = *iter;
     const auto& associatedTrackList = aClus->GetAssociatedTrackList();
 
@@ -126,8 +125,11 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::Run() {
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->CreatePfoFromTrack(trackList));
 
   if (!pPfoList->empty()) {
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                             PandoraContentApi::SaveList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(
+        pandora::STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::ReplaceCurrentList<pandora::ParticleFlowObject>(*this, m_outputPfoListName));
   }
 
   return pandora::STATUS_CODE_SUCCESS;
@@ -138,11 +140,12 @@ float IdeaPfoCreationAlgorithm::CaloSigma(float p, bool isEm) const {
     return std::numeric_limits<float>::max();
 
   const float stoch = isEm ? m_stochasticEm : m_stochasticHad;
-  const float cst   = isEm ? m_constantEm   : m_constantHad;
+  const float cst = isEm ? m_constantEm : m_constantHad;
   return std::max(m_sigmaFloor, stoch / std::sqrt(p) + cst);
 }
 
-pandora::StatusCode IdeaPfoCreationAlgorithm::CreateElectronCandidates(const pandora::ClusterList& /*clusterList*/) const {
+pandora::StatusCode
+IdeaPfoCreationAlgorithm::CreateElectronCandidates(const pandora::ClusterList& /*clusterList*/) const {
   // No electron ID yet -> all track-associated clusters are handled by the charged-hadron branch
   // (electrons inside jets are rare).  Disabled (not removed): original body commented out below.
   return pandora::STATUS_CODE_SUCCESS;
@@ -195,20 +198,22 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateElectronCandidates(const pan
     pfoParameters.m_momentum = momentum;
     pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::E_MINUS);
     pfoParameters.m_charge = bestTrack->GetCharge();
-    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::E_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::E_MINUS);
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ?
+  pandora::PdgTable::GetParticlePdgCode(pandora::E_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::E_MINUS);
 
     // TODO add vertex
 
     // Create the pfo
     const pandora::ParticleFlowObject* aPFO = nullptr;
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
-  } // cluster loop
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this,
+  pfoParameters, aPFO)); } // cluster loop
 
   return pandora::STATUS_CODE_SUCCESS;
   */
 } // CreateElectronCandidates
 
-pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(const pandora::ClusterList& clusterList) const {
+pandora::StatusCode
+IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(const pandora::ClusterList& clusterList) const {
   // ---- regional-excess significance gate for the charged-hadron energy -------------------------------
   //   Single-track cluster: over a 3D opening-angle cone (m_coneOpeningAngle), sum E_DR of ALL clusters
   //   (charged + neutral) and p of all associated tracks.  Form the regional neutral excess and its
@@ -228,7 +233,11 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(cons
   const pandora::ClusterList* fullClusterList = nullptr;
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, fullClusterList));
 
-  struct RegInfo { pandora::CartesianVector dir; float edr; float sumP; };
+  struct RegInfo {
+    pandora::CartesianVector dir;
+    float edr;
+    float sumP;
+  };
   std::unordered_map<const pandora::Cluster*, RegInfo> cache;
   cache.reserve(fullClusterList->size());
   for (const auto* c : *fullClusterList) {
@@ -236,18 +245,18 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(cons
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, this->GetDualReadoutEnergy(c, edr));
     float sumP = 0.f;
     for (const auto* trk : c->GetAssociatedTrackList())
-      sumP += trk->GetMomentumAtDca().GetMagnitude();       // sum ALL associated tracks (not best)
+      sumP += trk->GetMomentumAtDca().GetMagnitude(); // sum ALL associated tracks (not best)
     cache.emplace(c, RegInfo{c->GetCentroid(c->GetInnerPseudoLayer()).GetUnitVector(), edr, sumP});
   }
 
   const float cosCone = std::cos(m_coneOpeningAngle);
 
   // loop over the (track-associated) charged clusters and build the PFOs
-  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++iter) {
     const pandora::Cluster* const aClus = *iter;
 
     const auto& associatedTrackList = aClus->GetAssociatedTrackList();
-    const bool  hasMutlipleTracks = associatedTrackList.size() > 1;
+    const bool hasMutlipleTracks = associatedTrackList.size() > 1;
 
     // create PFO
     PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
@@ -261,45 +270,49 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(cons
     const auto* bestTrack = FindBestAssociatedTrack(aClus);
 
     const RegInfo& self = cache.at(aClus);
-    const float clusterEnergy = self.edr;                   // this cluster's E_DR (from the cache)
-    const float trackP        = bestTrack->GetMomentumAtDca().GetMagnitude();
+    const float clusterEnergy = self.edr; // this cluster's E_DR (from the cache)
+    const float trackP = bestTrack->GetMomentumAtDca().GetMagnitude();
 
     // regional E/p over the opening-angle cone (self included: cos = 1 > cosCone)
     float sumEdr = 0.f, sumP = 0.f;
     for (const auto& kv : cache) {
       if (self.dir.GetCosOpeningAngle(kv.second.dir) > cosCone) {
         sumEdr += kv.second.edr;
-        sumP   += kv.second.sumP;
+        sumP += kv.second.sumP;
       }
     }
-    const float sigmaReg  = CaloSigma(sumEdr, /*isEm=*/false);     // fractional hadronic sigma at the regional E_DR
-    const float regExcess = sumEdr - sumP;                         // regional neutral energy (calo above tracks)
-    const bool  gateFires = regExcess > m_significanceK * sigmaReg * sumEdr;   // S = regExcess/(sigma_c*sumEdr) > k
-    const float clusterExcess = clusterEnergy - trackP;           // this cluster's calo-minus-track energy
+    const float sigmaReg = CaloSigma(sumEdr, /*isEm=*/false); // fractional hadronic sigma at the regional E_DR
+    const float regExcess = sumEdr - sumP;                    // regional neutral energy (calo above tracks)
+    const bool gateFires = regExcess > m_significanceK * sigmaReg * sumEdr; // S = regExcess/(sigma_c*sumEdr) > k
+    const float clusterExcess = clusterEnergy - trackP;                     // this cluster's calo-minus-track energy
 
-    float energy       = trackP;                                  // charged PFO keeps the exact track p (never inflated)
-    auto  momentum     = bestTrack->GetMomentumAtDca();           // track (IP) momentum, magnitude p
+    float energy = trackP;                         // charged PFO keeps the exact track p (never inflated)
+    auto momentum = bestTrack->GetMomentumAtDca(); // track (IP) momentum, magnitude p
     float newNeutralEn = 0.f;
 
     if (hasMutlipleTracks) {
-      energy   = clusterEnergy;                                   // multi-track -> whole E_DR at centroid
+      energy = clusterEnergy; // multi-track -> whole E_DR at centroid
       momentum = self.dir * energy;
     } else if (gateFires && clusterExcess > 0.f) {
-      newNeutralEn = clusterExcess;                               // gate fires: emit the FULL excess as a real neutral
+      newNeutralEn = clusterExcess; // gate fires: emit the FULL excess as a real neutral
     }
     // else: pure charged -> energy = trackP, no neutral
 
     pfoParameters.m_energy = energy;
     pfoParameters.m_momentum = momentum;
-    pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::PI_PLUS); // TODO pion mass for now (revisit after K-pi separation)
+    pfoParameters.m_mass =
+        pandora::PdgTable::GetParticleMass(pandora::PI_PLUS); // TODO pion mass for now (revisit after K-pi separation)
     pfoParameters.m_charge = bestTrack->GetCharge();
-    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::PI_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::PI_MINUS);
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0)
+                                     ? pandora::PdgTable::GetParticlePdgCode(pandora::PI_PLUS)
+                                     : pandora::PdgTable::GetParticlePdgCode(pandora::PI_MINUS);
 
     // TODO add vertex
 
     // Create the charged pfo
     const pandora::ParticleFlowObject* aPFO = nullptr;
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                             PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
 
     // Emitted co-axial neutral (gate fired) -> separate neutral-hadron PFO along the cluster centroid.
     // It carries NO cluster: Pandora enforces exclusive cluster->PFO ownership (the charged PFO already
@@ -308,14 +321,14 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(cons
     // 4-momentum (energy = excess, centroid direction).
     if (newNeutralEn > 0.f) {
       PandoraContentApi::ParticleFlowObject::Parameters nhParams;
-      nhParams.m_energy     = newNeutralEn;
-      nhParams.m_momentum   = self.dir * newNeutralEn;
-      nhParams.m_mass       = pandora::PdgTable::GetParticleMass(pandora::K_LONG);
-      nhParams.m_charge     = 0.f;
+      nhParams.m_energy = newNeutralEn;
+      nhParams.m_momentum = self.dir * newNeutralEn;
+      nhParams.m_mass = pandora::PdgTable::GetParticleMass(pandora::K_LONG);
+      nhParams.m_charge = 0.f;
       nhParams.m_particleId = pandora::PdgTable::GetParticlePdgCode(pandora::K_LONG);
       const pandora::ParticleFlowObject* nhPFO = nullptr;
       PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-          PandoraContentApi::ParticleFlowObject::Create(*this, nhParams, nhPFO));
+                               PandoraContentApi::ParticleFlowObject::Create(*this, nhParams, nhPFO));
     }
   }
 
@@ -324,7 +337,7 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateChargedHadronCandidates(cons
 
 pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePhotonCandidates(const pandora::ClusterList& clusterList) const {
   // loop over clusters
-  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++iter) {
     const pandora::Cluster* const aClus = *iter;
 
     // use photon flag set upstream
@@ -351,15 +364,17 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePhotonCandidates(const pando
 
     // Create the pfo
     const pandora::ParticleFlowObject* aPFO = nullptr;
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                             PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
   }
 
   return pandora::STATUS_CODE_SUCCESS;
 } // CreatePhotonCandidates
 
-pandora::StatusCode IdeaPfoCreationAlgorithm::CreateNeutralHadronCandidates(const pandora::ClusterList& clusterList) const {
+pandora::StatusCode
+IdeaPfoCreationAlgorithm::CreateNeutralHadronCandidates(const pandora::ClusterList& clusterList) const {
   // loop over clusters
-  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++ iter) {
+  for (auto iter = clusterList.begin(); iter != clusterList.end(); ++iter) {
     const pandora::Cluster* const aClus = *iter;
 
     if (aClus->GetParticleId() == pandora::PHOTON)
@@ -393,7 +408,8 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreateNeutralHadronCandidates(cons
 
     // Create the pfo
     const pandora::ParticleFlowObject* aPFO = nullptr;
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                             PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
   }
 
   return pandora::STATUS_CODE_SUCCESS;
@@ -438,11 +454,13 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePfoFromTrack(const pandora::
     pfoParameters.m_momentum = momentum;
     pfoParameters.m_mass = pandora::PdgTable::GetParticleMass(pandora::MU_MINUS); // muon for now
     pfoParameters.m_charge = track->GetCharge();
-    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ? pandora::PdgTable::GetParticlePdgCode(pandora::MU_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::MU_MINUS);
+    pfoParameters.m_particleId = (pfoParameters.m_charge.Get() > 0) ?
+  pandora::PdgTable::GetParticlePdgCode(pandora::MU_PLUS) : pandora::PdgTable::GetParticlePdgCode(pandora::MU_MINUS);
 
     // Create the pfo
     const pandora::ParticleFlowObject* aPFO = nullptr;
-    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, aPFO));
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this,
+  pfoParameters, aPFO));
   }
 
   return pandora::STATUS_CODE_SUCCESS;
@@ -450,37 +468,37 @@ pandora::StatusCode IdeaPfoCreationAlgorithm::CreatePfoFromTrack(const pandora::
 } // CreatePfoFromTrack
 
 pandora::StatusCode IdeaPfoCreationAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "OutputPfoListName", m_outputPfoListName));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "NSigma", m_nSigma));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "NSigma", m_nSigma));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "StochasticTermHad", m_stochasticHad));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StochasticTermHad", m_stochasticHad));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "ConstantTermHad", m_constantHad));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "ConstantTermHad", m_constantHad));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "StochasticTermEm", m_stochasticEm));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "StochasticTermEm", m_stochasticEm));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "ConstantTermEm", m_constantEm));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "ConstantTermEm", m_constantEm));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "PtCut", m_ptCut));
+  PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "PtCut", m_ptCut));
 
   // regional-excess significance gate on the charged-hadron energy
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "ConeOpeningAngle", m_coneOpeningAngle));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "ConeOpeningAngle", m_coneOpeningAngle));
 
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "SignificanceK", m_significanceK));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "SignificanceK", m_significanceK));
 
   // flat neutral-hadron energy calibration (independent of the regression; default 1.10)
   PANDORA_RETURN_RESULT_IF_AND_IF(pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
-      pandora::XmlHelper::ReadValue(xmlHandle, "NeutralHadEnergyScale", m_neutralHadScale));
+                                  pandora::XmlHelper::ReadValue(xmlHandle, "NeutralHadEnergyScale", m_neutralHadScale));
 
   return pandora::STATUS_CODE_SUCCESS;
 }

--- a/src/LCPlugins/DualReadoutCorrection.cc
+++ b/src/LCPlugins/DualReadoutCorrection.cc
@@ -1,0 +1,86 @@
+/**
+ *  @file   LCContent/src/LCPlugins/DualReadoutCorrection.cc
+ * 
+ *  @brief  Implementation of the dual-readout correction plugin algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "LCPlugins/DualReadoutCorrection.h"
+
+namespace lc_content {
+
+DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus,
+                                           const float chiEcal, const float chiHcal) {
+  // initialize output struct
+  DualReadoutEnergy out;
+
+  pandora::CaloHitList pandoraCaloHitList;
+  aClus->GetOrderedCaloHitList().FillCaloHitList(pandoraCaloHitList);
+  const auto& isolatedHits = aClus->GetIsolatedCaloHitList();
+
+  if (pandoraCaloHitList.empty())
+    return out;
+
+  for (const pandora::CaloHitList& hitList : {pandoraCaloHitList, isolatedHits}) {
+    for (const auto* hit : hitList) {
+      float ecalEnergy = hit->GetElectromagneticEnergy();
+      float hcalEnergy = hit->GetHadronicEnergy();
+
+      if (ecalEnergy > 0.f) {
+        if (hit->GetHitType() == pandora::DRC_SCINT) {
+          out.ecalS += ecalEnergy;
+          out.ecalS_byDepth[hit->GetLayer()] += ecalEnergy;
+        } else if (hit->GetHitType() == pandora::DRC_CHEREN) {
+          out.ecalC += ecalEnergy;
+          out.ecalC_byDepth[hit->GetLayer()] += ecalEnergy;
+        }
+      }
+
+      if (hcalEnergy > 0.f) {
+        if (hit->GetHitType() == pandora::DRC_SCINT)
+          out.hcalS += hcalEnergy;
+        else if (hit->GetHitType() == pandora::DRC_CHEREN)
+          out.hcalC += hcalEnergy;
+      }
+    } // hit loop
+  } // loop over hit lists (regular hits and isolated hits)
+
+  // apply dual-readout correction
+  // Note: we assume that chiEcal and chiHcal inputs are checked to be less than 1
+  // so that the denominators here are not close to zero
+  // (it should be checked in the ReadSettings of the plugin)
+  out.energyEcalCorrected = (out.ecalS - chiEcal * out.ecalC) / (1.f - chiEcal);
+  out.energyHcalCorrected = (out.hcalS - chiHcal * out.hcalC) / (1.f - chiHcal);
+
+  return out;
+} // RunDualReadoutCorrection
+
+pandora::StatusCode DualReadoutCorrection::MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const {
+  auto dualReadoutEnergy(RunDualReadoutCorrection(pCluster, m_chiEcal, m_chiHcal));
+
+  // use the sum of corrected ECAL and HCAL energy as the corrected energy
+  correctedEnergy = dualReadoutEnergy.energyEcalCorrected + dualReadoutEnergy.energyHcalCorrected;
+
+  return pandora::STATUS_CODE_SUCCESS;
+}
+
+pandora::StatusCode DualReadoutCorrection::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "ChiEcal", m_chiEcal));
+
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, pandora::XmlHelper::ReadValue(xmlHandle,
+      "ChiHcal", m_chiHcal));
+
+  if (m_chiEcal >= 1.f || m_chiHcal >= 1.f || m_chiEcal <= 0.f || m_chiHcal <= 0.f) {
+    std::cerr << "DualReadoutCorrection::ReadSettings: ChiEcal and ChiHcal must be 0 < chi < 1";
+    std::cerr << " to avoid singularity in dual-readout correction." << std::endl;
+
+    return pandora::STATUS_CODE_INVALID_PARAMETER;
+  }
+
+  return pandora::STATUS_CODE_SUCCESS;
+} // ReadSettings
+
+} // namespace lc_content

--- a/src/LCPlugins/DualReadoutCorrection.cc
+++ b/src/LCPlugins/DualReadoutCorrection.cc
@@ -1,18 +1,18 @@
 /**
  *  @file   LCContent/src/LCPlugins/DualReadoutCorrection.cc
- * 
+ *
  *  @brief  Implementation of the dual-readout correction plugin algorithm class.
  *
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "LCPlugins/DualReadoutCorrection.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 namespace lc_content {
 
-DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus,
-                                           const float chiEcal, const float chiHcal) {
+DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus, const float chiEcal,
+                                           const float chiHcal) {
   // initialize output struct
   DualReadoutEnergy out;
 
@@ -57,7 +57,8 @@ DualReadoutEnergy RunDualReadoutCorrection(const pandora::Cluster* const aClus,
   return out;
 } // RunDualReadoutCorrection
 
-pandora::StatusCode DualReadoutCorrection::MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const {
+pandora::StatusCode DualReadoutCorrection::MakeEnergyCorrections(const pandora::Cluster* const pCluster,
+                                                                 float& correctedEnergy) const {
   auto dualReadoutEnergy(RunDualReadoutCorrection(pCluster, m_chiEcal, m_chiHcal));
 
   // use the sum of corrected ECAL and HCAL energy as the corrected energy
@@ -67,11 +68,11 @@ pandora::StatusCode DualReadoutCorrection::MakeEnergyCorrections(const pandora::
 }
 
 pandora::StatusCode DualReadoutCorrection::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "ChiEcal", m_chiEcal));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           pandora::XmlHelper::ReadValue(xmlHandle, "ChiEcal", m_chiEcal));
 
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, pandora::XmlHelper::ReadValue(xmlHandle,
-      "ChiHcal", m_chiHcal));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           pandora::XmlHelper::ReadValue(xmlHandle, "ChiHcal", m_chiHcal));
 
   if (m_chiEcal >= 1.f || m_chiHcal >= 1.f || m_chiEcal <= 0.f || m_chiHcal <= 0.f) {
     std::cerr << "DualReadoutCorrection::ReadSettings: ChiEcal and ChiHcal must be 0 < chi < 1";

--- a/src/MLInference/ClusterNeutralPidAlgorithm.cc
+++ b/src/MLInference/ClusterNeutralPidAlgorithm.cc
@@ -39,15 +39,8 @@ namespace lc_content {
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 ClusterNeutralPidAlgorithm::ClusterNeutralPidAlgorithm()
-    : m_modelPath(""),
-      m_w0(4.6f),
-      m_coneLateralMm(250.f),
-      m_budgetOwnEcal(200),
-      m_budgetOtherEcal(150),
-      m_budgetHcal(150),
-      m_budgetTrack(20),
-      m_photonThreshold(-1.f),
-      m_maxTokens(0) {}
+    : m_modelPath(""), m_w0(4.6f), m_coneLateralMm(250.f), m_budgetOwnEcal(200), m_budgetOtherEcal(150),
+      m_budgetHcal(150), m_budgetTrack(20), m_photonThreshold(-1.f), m_maxTokens(0) {}
 
 ClusterNeutralPidAlgorithm::~ClusterNeutralPidAlgorithm() = default;
 
@@ -56,18 +49,20 @@ ClusterNeutralPidAlgorithm::~ClusterNeutralPidAlgorithm() = default;
 int ClusterNeutralPidAlgorithm::Decide(float s0, float s1, float s2) const {
   // raw model scores in order [satellite, neutral-hadron, photon]; photon is a score cut
   if (m_photonThreshold >= 0.f) {
-    if (s2 > m_photonThreshold) return PHOTON;
+    if (s2 > m_photonThreshold)
+      return PHOTON;
     return (s1 > s0) ? K_LONG : UNKNOWN_PARTICLE_TYPE;
   }
   // no threshold configured: fall back to argmax over the three scores
-  if (s2 >= s1 && s2 >= s0) return PHOTON;
+  if (s2 >= s1 && s2 >= s0)
+    return PHOTON;
   return (s1 > s0) ? K_LONG : UNKNOWN_PARTICLE_TYPE;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ClusterNeutralPidAlgorithm::Run() {
-  const ClusterList *pClusterList = nullptr;
+  const ClusterList* pClusterList = nullptr;
   PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
   if (pClusterList->empty())
     return STATUS_CODE_SUCCESS;
@@ -75,41 +70,47 @@ StatusCode ClusterNeutralPidAlgorithm::Run() {
   // ------------------------------------------------------------------
   // 1. Hit pool: the current CaloHitList is the superset of all hits.
   // ------------------------------------------------------------------
-  const CaloHitList *pCaloHitList = nullptr;
+  const CaloHitList* pCaloHitList = nullptr;
   PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
 
   std::vector<Hit> hits;
   hits.reserve(pCaloHitList->size());
-  for (const CaloHit *const pHit : *pCaloHitList) {
+  for (const CaloHit* const pHit : *pCaloHitList) {
     const float e = pHit->GetInputEnergy();
-    if (e <= 0.f) continue;
-    const CartesianVector &p = pHit->GetPositionVector();
+    if (e <= 0.f)
+      continue;
+    const CartesianVector& p = pHit->GetPositionVector();
     float r, phi, theta;
-    p.GetSphericalCoordinates(r, phi, theta);   // a calo hit is never at the origin
+    p.GetSphericalCoordinates(r, phi, theta); // a calo hit is never at the origin
     const CartesianVector u = p.GetUnitVector();
     Hit hh;
-    hh.ux = u.GetX(); hh.uy = u.GetY(); hh.uz = u.GetZ();
-    hh.th = theta;    hh.ph = phi;       hh.e  = e;
-    hh.isEcal    = (pHit->GetHadronicEnergy() <= 0.f);
-    hh.cherFeat  = (pHit->GetHitType() == DRC_CHEREN) ? 1.f : 0.f;
-    hh.depthFeat = static_cast<float>(pHit->GetLayer());   // used only for ECAL tokens
-    hh.pCaloHit  = pHit;
+    hh.ux = u.GetX();
+    hh.uy = u.GetY();
+    hh.uz = u.GetZ();
+    hh.th = theta;
+    hh.ph = phi;
+    hh.e = e;
+    hh.isEcal = (pHit->GetHadronicEnergy() <= 0.f);
+    hh.cherFeat = (pHit->GetHitType() == DRC_CHEREN) ? 1.f : 0.f;
+    hh.depthFeat = static_cast<float>(pHit->GetLayer()); // used only for ECAL tokens
+    hh.pCaloHit = pHit;
     hits.push_back(hh);
   }
 
   // ------------------------------------------------------------------
   // 2. Track impacts at the calorimeter.
   // ------------------------------------------------------------------
-  const TrackList *pTrackList = nullptr;
+  const TrackList* pTrackList = nullptr;
   PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pTrackList));
 
   std::vector<TrackImpact> impacts;
-  for (const Track *const pTrack : *pTrackList) {
+  for (const Track* const pTrack : *pTrackList) {
     // skip before GetSphericalCoordinates: the calo track-state position is (0,0,0)
     // when the track does not reach the calorimeter (which would otherwise throw).
-    if (!pTrack->ReachesCalorimeter()) continue;
-    const TrackState &ts = pTrack->GetTrackStateAtCalorimeter();
-    const CartesianVector &pos = ts.GetPosition();
+    if (!pTrack->ReachesCalorimeter())
+      continue;
+    const TrackState& ts = pTrack->GetTrackStateAtCalorimeter();
+    const CartesianVector& pos = ts.GetPosition();
     float r, phi, theta;
     pos.GetSphericalCoordinates(r, phi, theta);
     const CartesianVector u = pos.GetUnitVector();
@@ -119,29 +120,34 @@ StatusCode ClusterNeutralPidAlgorithm::Run() {
   // ------------------------------------------------------------------
   // 3. Per-cluster tokenisation + inference + PID write-out.
   // ------------------------------------------------------------------
-  std::vector<float>      tokens(static_cast<std::size_t>(m_maxTokens) * N_FEAT);
-  std::vector<int64_t>    typeIds(static_cast<std::size_t>(m_maxTokens));
+  std::vector<float> tokens(static_cast<std::size_t>(m_maxTokens) * N_FEAT);
+  std::vector<int64_t> typeIds(static_cast<std::size_t>(m_maxTokens));
   std::unique_ptr<bool[]> mask(new bool[m_maxTokens]);
 
-  struct Row { std::array<float, N_FEAT> f; float intensity; int64_t typeId; };
+  struct Row {
+    std::array<float, N_FEAT> f;
+    float intensity;
+    int64_t typeId;
+  };
   std::vector<Row> ownList, otherList, hcalList, trkList;
 
-  for (const Cluster *const pCluster : *pClusterList) {
+  for (const Cluster* const pCluster : *pClusterList) {
     // skip clusters already associated with a track (charged): their identity is
     // resolved by track-cluster matching, and the model excludes charged primaries.
     if (!pCluster->GetAssociatedTrackList().empty())
       continue;
 
-    int particleId = UNKNOWN_PARTICLE_TYPE;   // satellite / untokenisable -> UNKNOWN
+    int particleId = UNKNOWN_PARTICLE_TYPE; // satellite / untokenisable -> UNKNOWN
 
     // ---- own-hit set + total energy (for the log-weighted barycenter) ----
-    std::set<const CaloHit *> ownSet;
+    std::set<const CaloHit*> ownSet;
     float eTotal = 0.f;
-    for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
-      for (const CaloHit *const pHit : *layerEntry.second) {
+    for (const auto& layerEntry : pCluster->GetOrderedCaloHitList()) {
+      for (const CaloHit* const pHit : *layerEntry.second) {
         ownSet.insert(pHit);
         const float e = pHit->GetInputEnergy();
-        if (e > 0.f) eTotal += e;
+        if (e > 0.f)
+          eTotal += e;
       }
     }
 
@@ -149,36 +155,43 @@ StatusCode ClusterNeutralPidAlgorithm::Run() {
     // reproduces the k4 cluster position the model trained against.
     double sx = 0., sy = 0., sz = 0., sw = 0.;
     if (eTotal > 0.f) {
-      for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
-        for (const CaloHit *const pHit : *layerEntry.second) {
+      for (const auto& layerEntry : pCluster->GetOrderedCaloHitList()) {
+        for (const CaloHit* const pHit : *layerEntry.second) {
           const float e = pHit->GetInputEnergy();
-          if (e <= 0.f) continue;
+          if (e <= 0.f)
+            continue;
           const float w = m_w0 + std::log(e / eTotal);
-          if (w <= 0.f) continue;
-          const CartesianVector &p = pHit->GetPositionVector();
-          sx += p.GetX() * w; sy += p.GetY() * w; sz += p.GetZ() * w; sw += w;
+          if (w <= 0.f)
+            continue;
+          const CartesianVector& p = pHit->GetPositionVector();
+          sx += p.GetX() * w;
+          sy += p.GetY() * w;
+          sz += p.GetZ() * w;
+          sw += w;
         }
       }
     }
 
     if (sw > 0.) {
-      const CartesianVector centroid(static_cast<float>(sx / sw),
-                                     static_cast<float>(sy / sw),
+      const CartesianVector centroid(static_cast<float>(sx / sw), static_cast<float>(sy / sw),
                                      static_cast<float>(sz / sw));
       float rC, phC, thC;
-      centroid.GetSphericalCoordinates(rC, phC, thC);   // log-weighted barycenter, at calo radius
+      centroid.GetSphericalCoordinates(rC, phC, thC); // log-weighted barycenter, at calo radius
       const CartesianVector uc = centroid.GetUnitVector();
       const float ucx = uc.GetX(), ucy = uc.GetY(), ucz = uc.GetZ();
       const float cosAlpha = std::cos(std::atan(m_coneLateralMm / rC));
 
-      ownList.clear(); otherList.clear(); hcalList.clear(); trkList.clear();
+      ownList.clear();
+      otherList.clear();
+      hcalList.clear();
+      trkList.clear();
 
-      for (const Hit &h : hits) {
-        const bool  inOwn   = ownSet.count(h.pCaloHit) > 0;
-        const float cosGeom = ucx*h.ux + ucy*h.uy + ucz*h.uz;
-        const float dth     = h.th - thC;
-        const float dph     = VectorHelper::deltaPhi(h.ph, phC);
-        const float lnE     = std::log(h.e);
+      for (const Hit& h : hits) {
+        const bool inOwn = ownSet.count(h.pCaloHit) > 0;
+        const float cosGeom = ucx * h.ux + ucy * h.uy + ucz * h.uz;
+        const float dth = h.th - thC;
+        const float dph = VectorHelper::deltaPhi(h.ph, phC);
+        const float lnE = std::log(h.e);
 
         if (h.isEcal && inOwn) {
           ownList.push_back({{dth, dph, h.depthFeat, lnE, h.cherFeat}, h.e, TID_OWN});
@@ -189,53 +202,59 @@ StatusCode ClusterNeutralPidAlgorithm::Run() {
         }
       }
 
-      for (const TrackImpact &imp : impacts) {
-        const float cosGeom = ucx*imp.ux + ucy*imp.uy + ucz*imp.uz;
-        if (cosGeom < cosAlpha) continue;
+      for (const TrackImpact& imp : impacts) {
+        const float cosGeom = ucx * imp.ux + ucy * imp.uy + ucz * imp.uz;
+        if (cosGeom < cosAlpha)
+          continue;
         const float dth = imp.th - thC;
         const float dph = VectorHelper::deltaPhi(imp.ph, phC);
         const float lnP = std::log(std::max(imp.p, 1e-6f));
         trkList.push_back({{dth, dph, FEATURE_ABSENT, lnP, FEATURE_ABSENT}, imp.p, TID_TRACK});
       }
 
-      auto trim = [](std::vector<Row> &v, int k) {
-        if (static_cast<int>(v.size()) <= k) return;
+      auto trim = [](std::vector<Row>& v, int k) {
+        if (static_cast<int>(v.size()) <= k)
+          return;
         std::nth_element(v.begin(), v.begin() + k, v.end(),
-                         [](const Row &a, const Row &b) { return a.intensity > b.intensity; });
+                         [](const Row& a, const Row& b) { return a.intensity > b.intensity; });
         v.resize(static_cast<std::size_t>(k));
       };
-      trim(ownList,   m_budgetOwnEcal);
+      trim(ownList, m_budgetOwnEcal);
       trim(otherList, m_budgetOtherEcal);
-      trim(hcalList,  m_budgetHcal);
-      trim(trkList,   m_budgetTrack);
+      trim(hcalList, m_budgetHcal);
+      trim(trkList, m_budgetTrack);
 
       std::fill(tokens.begin(), tokens.end(), 0.f);
       std::fill(typeIds.begin(), typeIds.end(), int64_t{0});
-      std::fill(mask.get(), mask.get() + m_maxTokens, true);   // true = padding (masked)
+      std::fill(mask.get(), mask.get() + m_maxTokens, true); // true = padding (masked)
 
       std::size_t idx = 0;
-      auto emit = [&](const std::vector<Row> &v) {
-        for (const Row &r : v) {
+      auto emit = [&](const std::vector<Row>& v) {
+        for (const Row& r : v) {
           const std::size_t off = idx * N_FEAT;
-          for (int k = 0; k < N_FEAT; ++k) tokens[off + k] = r.f[k];
+          for (int k = 0; k < N_FEAT; ++k)
+            tokens[off + k] = r.f[k];
           typeIds[idx] = r.typeId;
-          mask[idx]    = false;
+          mask[idx] = false;
           ++idx;
         }
       };
-      emit(ownList); emit(otherList); emit(hcalList); emit(trkList);
+      emit(ownList);
+      emit(otherList);
+      emit(hcalList);
+      emit(trkList);
 
       const int64_t maxTok = static_cast<int64_t>(m_maxTokens);
       const std::vector<OnnxSession::Input> inputs = {
           {{1, maxTok, N_FEAT}, OnnxSession::Input::Type::Float, tokens.data()},
-          {{1, maxTok},         OnnxSession::Input::Type::Int64, typeIds.data()},
-          {{1, maxTok},         OnnxSession::Input::Type::Bool,  mask.get()},
+          {{1, maxTok}, OnnxSession::Input::Type::Int64, typeIds.data()},
+          {{1, maxTok}, OnnxSession::Input::Type::Bool, mask.get()},
       };
       const std::vector<std::vector<float>> outputs = m_session->Run(inputs);
       if (outputs.empty() || outputs[0].size() < static_cast<std::size_t>(N_CLASSES)) {
-        particleId = UNKNOWN_PARTICLE_TYPE;                               // inference failed -> UNKNOWN
+        particleId = UNKNOWN_PARTICLE_TYPE; // inference failed -> UNKNOWN
       } else {
-        const std::vector<float> &scores = outputs[0];                    // [sat, NH, photon]
+        const std::vector<float>& scores = outputs[0]; // [sat, NH, photon]
         particleId = Decide(scores[0], scores[1], scores[2]);
       }
     }
@@ -244,7 +263,7 @@ StatusCode ClusterNeutralPidAlgorithm::Run() {
     PandoraContentApi::Cluster::Metadata metadata;
     metadata.m_particleId = particleId;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-        PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
+                             PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
   }
 
   return STATUS_CODE_SUCCESS;
@@ -267,10 +286,9 @@ StatusCode ClusterNeutralPidAlgorithm::LoadModel() {
   }
 
   const std::vector<std::int64_t> tokensShape = m_session->InputShape(0);
-  if (tokensShape.size() == 3 && tokensShape[1] > 0 &&
-      tokensShape[1] != static_cast<std::int64_t>(m_maxTokens)) {
-    std::cout << "ClusterNeutralPidAlgorithm: model MAX_TOKENS=" << tokensShape[1]
-              << " != configured budget sum " << m_maxTokens << "." << std::endl;
+  if (tokensShape.size() == 3 && tokensShape[1] > 0 && tokensShape[1] != static_cast<std::int64_t>(m_maxTokens)) {
+    std::cout << "ClusterNeutralPidAlgorithm: model MAX_TOKENS=" << tokensShape[1] << " != configured budget sum "
+              << m_maxTokens << "." << std::endl;
     return STATUS_CODE_FAILURE;
   }
   return STATUS_CODE_SUCCESS;
@@ -279,22 +297,21 @@ StatusCode ClusterNeutralPidAlgorithm::LoadModel() {
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ClusterNeutralPidAlgorithm::ReadSettings(const TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath));
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+                                  XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "ConeLateralMm", m_coneLateralMm));
+                                  XmlHelper::ReadValue(xmlHandle, "ConeLateralMm", m_coneLateralMm));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetOwnEcal", m_budgetOwnEcal));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetOwnEcal", m_budgetOwnEcal));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetOtherEcal", m_budgetOtherEcal));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetOtherEcal", m_budgetOtherEcal));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetHcal", m_budgetHcal));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetHcal", m_budgetHcal));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetTrack", m_budgetTrack));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetTrack", m_budgetTrack));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "PhotonThreshold", m_photonThreshold));
+                                  XmlHelper::ReadValue(xmlHandle, "PhotonThreshold", m_photonThreshold));
 
   m_maxTokens = m_budgetOwnEcal + m_budgetOtherEcal + m_budgetHcal + m_budgetTrack;
   return this->LoadModel();

--- a/src/MLInference/ClusterNeutralPidAlgorithm.cc
+++ b/src/MLInference/ClusterNeutralPidAlgorithm.cc
@@ -1,0 +1,303 @@
+/**
+ *  @file   LCContent/src/MLInference/ClusterNeutralPidAlgorithm.cc
+ *
+ *  @brief  Implementation of the neutral-PID (sat/NH/photon) ONNX tagging algorithm.
+ *
+ *  Port of k4RecCalorimeter ClusterNeutralPidOnnx.  Tokenisation, feature layout and
+ *  decision rule are kept 1:1 with that algorithm and with photonId_hitcollect_multi.py.
+ *  Pandora accessors give exact feature parity (no cellID decode needed):
+ *    ln E      <- CaloHit::GetInputEnergy()        (the digi-channel energy)
+ *    is_cher   <- CaloHit::GetHitType()==DRC_CHEREN
+ *    depth     <- CaloHit::GetLayer()              (= the cellID layer/"depth" field)
+ *    ECAL/HCAL <- CaloHit::GetHadronicEnergy()<=0  => ECAL
+ *    dTheta,dPhi <- CaloHit::GetPositionVector()
+ *    track     <- Track::GetTrackStateAtCalorimeter().GetPosition()/.GetMomentum()
+ *
+ *  The model output is already a per-class score (no softmax applied here); the photon
+ *  decision is a direct score cut at PhotonThreshold.
+ */
+#include "MLInference/ClusterNeutralPidAlgorithm.h"
+
+#include "LCHelpers/VectorHelper.h"
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Pandora/PdgTable.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace pandora;
+
+namespace lc_content {
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+ClusterNeutralPidAlgorithm::ClusterNeutralPidAlgorithm()
+    : m_modelPath(""),
+      m_w0(4.6f),
+      m_coneLateralMm(250.f),
+      m_budgetOwnEcal(200),
+      m_budgetOtherEcal(150),
+      m_budgetHcal(150),
+      m_budgetTrack(20),
+      m_photonThreshold(-1.f),
+      m_maxTokens(0) {}
+
+ClusterNeutralPidAlgorithm::~ClusterNeutralPidAlgorithm() = default;
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int ClusterNeutralPidAlgorithm::Decide(float s0, float s1, float s2) const {
+  // raw model scores in order [satellite, neutral-hadron, photon]; photon is a score cut
+  if (m_photonThreshold >= 0.f) {
+    if (s2 > m_photonThreshold) return PHOTON;
+    return (s1 > s0) ? K_LONG : UNKNOWN_PARTICLE_TYPE;
+  }
+  // no threshold configured: fall back to argmax over the three scores
+  if (s2 >= s1 && s2 >= s0) return PHOTON;
+  return (s1 > s0) ? K_LONG : UNKNOWN_PARTICLE_TYPE;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ClusterNeutralPidAlgorithm::Run() {
+  const ClusterList *pClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
+  if (pClusterList->empty())
+    return STATUS_CODE_SUCCESS;
+
+  // ------------------------------------------------------------------
+  // 1. Hit pool: the current CaloHitList is the superset of all hits.
+  // ------------------------------------------------------------------
+  const CaloHitList *pCaloHitList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
+
+  std::vector<Hit> hits;
+  hits.reserve(pCaloHitList->size());
+  for (const CaloHit *const pHit : *pCaloHitList) {
+    const float e = pHit->GetInputEnergy();
+    if (e <= 0.f) continue;
+    const CartesianVector &p = pHit->GetPositionVector();
+    float r, phi, theta;
+    p.GetSphericalCoordinates(r, phi, theta);   // a calo hit is never at the origin
+    const CartesianVector u = p.GetUnitVector();
+    Hit hh;
+    hh.ux = u.GetX(); hh.uy = u.GetY(); hh.uz = u.GetZ();
+    hh.th = theta;    hh.ph = phi;       hh.e  = e;
+    hh.isEcal    = (pHit->GetHadronicEnergy() <= 0.f);
+    hh.cherFeat  = (pHit->GetHitType() == DRC_CHEREN) ? 1.f : 0.f;
+    hh.depthFeat = static_cast<float>(pHit->GetLayer());   // used only for ECAL tokens
+    hh.pCaloHit  = pHit;
+    hits.push_back(hh);
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Track impacts at the calorimeter.
+  // ------------------------------------------------------------------
+  const TrackList *pTrackList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pTrackList));
+
+  std::vector<TrackImpact> impacts;
+  for (const Track *const pTrack : *pTrackList) {
+    // skip before GetSphericalCoordinates: the calo track-state position is (0,0,0)
+    // when the track does not reach the calorimeter (which would otherwise throw).
+    if (!pTrack->ReachesCalorimeter()) continue;
+    const TrackState &ts = pTrack->GetTrackStateAtCalorimeter();
+    const CartesianVector &pos = ts.GetPosition();
+    float r, phi, theta;
+    pos.GetSphericalCoordinates(r, phi, theta);
+    const CartesianVector u = pos.GetUnitVector();
+    impacts.push_back({u.GetX(), u.GetY(), u.GetZ(), theta, phi, ts.GetMomentum().GetMagnitude()});
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Per-cluster tokenisation + inference + PID write-out.
+  // ------------------------------------------------------------------
+  std::vector<float>      tokens(static_cast<std::size_t>(m_maxTokens) * N_FEAT);
+  std::vector<int64_t>    typeIds(static_cast<std::size_t>(m_maxTokens));
+  std::unique_ptr<bool[]> mask(new bool[m_maxTokens]);
+
+  struct Row { std::array<float, N_FEAT> f; float intensity; int64_t typeId; };
+  std::vector<Row> ownList, otherList, hcalList, trkList;
+
+  for (const Cluster *const pCluster : *pClusterList) {
+    // skip clusters already associated with a track (charged): their identity is
+    // resolved by track-cluster matching, and the model excludes charged primaries.
+    if (!pCluster->GetAssociatedTrackList().empty())
+      continue;
+
+    int particleId = UNKNOWN_PARTICLE_TYPE;   // satellite / untokenisable -> UNKNOWN
+
+    // ---- own-hit set + total energy (for the log-weighted barycenter) ----
+    std::set<const CaloHit *> ownSet;
+    float eTotal = 0.f;
+    for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
+      for (const CaloHit *const pHit : *layerEntry.second) {
+        ownSet.insert(pHit);
+        const float e = pHit->GetInputEnergy();
+        if (e > 0.f) eTotal += e;
+      }
+    }
+
+    // ---- W0 log-weighted barycenter: w_i = max(0, m_w0 + ln(e_i / eTotal)) ----
+    // reproduces the k4 cluster position the model trained against.
+    double sx = 0., sy = 0., sz = 0., sw = 0.;
+    if (eTotal > 0.f) {
+      for (const auto &layerEntry : pCluster->GetOrderedCaloHitList()) {
+        for (const CaloHit *const pHit : *layerEntry.second) {
+          const float e = pHit->GetInputEnergy();
+          if (e <= 0.f) continue;
+          const float w = m_w0 + std::log(e / eTotal);
+          if (w <= 0.f) continue;
+          const CartesianVector &p = pHit->GetPositionVector();
+          sx += p.GetX() * w; sy += p.GetY() * w; sz += p.GetZ() * w; sw += w;
+        }
+      }
+    }
+
+    if (sw > 0.) {
+      const CartesianVector centroid(static_cast<float>(sx / sw),
+                                     static_cast<float>(sy / sw),
+                                     static_cast<float>(sz / sw));
+      float rC, phC, thC;
+      centroid.GetSphericalCoordinates(rC, phC, thC);   // log-weighted barycenter, at calo radius
+      const CartesianVector uc = centroid.GetUnitVector();
+      const float ucx = uc.GetX(), ucy = uc.GetY(), ucz = uc.GetZ();
+      const float cosAlpha = std::cos(std::atan(m_coneLateralMm / rC));
+
+      ownList.clear(); otherList.clear(); hcalList.clear(); trkList.clear();
+
+      for (const Hit &h : hits) {
+        const bool  inOwn   = ownSet.count(h.pCaloHit) > 0;
+        const float cosGeom = ucx*h.ux + ucy*h.uy + ucz*h.uz;
+        const float dth     = h.th - thC;
+        const float dph     = VectorHelper::deltaPhi(h.ph, phC);
+        const float lnE     = std::log(h.e);
+
+        if (h.isEcal && inOwn) {
+          ownList.push_back({{dth, dph, h.depthFeat, lnE, h.cherFeat}, h.e, TID_OWN});
+        } else if (h.isEcal && !inOwn && cosGeom >= cosAlpha) {
+          otherList.push_back({{dth, dph, h.depthFeat, lnE, h.cherFeat}, h.e, TID_OTHER});
+        } else if (!h.isEcal && cosGeom >= cosAlpha) {
+          hcalList.push_back({{dth, dph, FEATURE_ABSENT, lnE, h.cherFeat}, h.e, TID_HCAL});
+        }
+      }
+
+      for (const TrackImpact &imp : impacts) {
+        const float cosGeom = ucx*imp.ux + ucy*imp.uy + ucz*imp.uz;
+        if (cosGeom < cosAlpha) continue;
+        const float dth = imp.th - thC;
+        const float dph = VectorHelper::deltaPhi(imp.ph, phC);
+        const float lnP = std::log(std::max(imp.p, 1e-6f));
+        trkList.push_back({{dth, dph, FEATURE_ABSENT, lnP, FEATURE_ABSENT}, imp.p, TID_TRACK});
+      }
+
+      auto trim = [](std::vector<Row> &v, int k) {
+        if (static_cast<int>(v.size()) <= k) return;
+        std::nth_element(v.begin(), v.begin() + k, v.end(),
+                         [](const Row &a, const Row &b) { return a.intensity > b.intensity; });
+        v.resize(static_cast<std::size_t>(k));
+      };
+      trim(ownList,   m_budgetOwnEcal);
+      trim(otherList, m_budgetOtherEcal);
+      trim(hcalList,  m_budgetHcal);
+      trim(trkList,   m_budgetTrack);
+
+      std::fill(tokens.begin(), tokens.end(), 0.f);
+      std::fill(typeIds.begin(), typeIds.end(), int64_t{0});
+      std::fill(mask.get(), mask.get() + m_maxTokens, true);   // true = padding (masked)
+
+      std::size_t idx = 0;
+      auto emit = [&](const std::vector<Row> &v) {
+        for (const Row &r : v) {
+          const std::size_t off = idx * N_FEAT;
+          for (int k = 0; k < N_FEAT; ++k) tokens[off + k] = r.f[k];
+          typeIds[idx] = r.typeId;
+          mask[idx]    = false;
+          ++idx;
+        }
+      };
+      emit(ownList); emit(otherList); emit(hcalList); emit(trkList);
+
+      const int64_t maxTok = static_cast<int64_t>(m_maxTokens);
+      const std::vector<OnnxSession::Input> inputs = {
+          {{1, maxTok, N_FEAT}, OnnxSession::Input::Type::Float, tokens.data()},
+          {{1, maxTok},         OnnxSession::Input::Type::Int64, typeIds.data()},
+          {{1, maxTok},         OnnxSession::Input::Type::Bool,  mask.get()},
+      };
+      const std::vector<std::vector<float>> outputs = m_session->Run(inputs);
+      if (outputs.empty() || outputs[0].size() < static_cast<std::size_t>(N_CLASSES)) {
+        particleId = UNKNOWN_PARTICLE_TYPE;                               // inference failed -> UNKNOWN
+      } else {
+        const std::vector<float> &scores = outputs[0];                    // [sat, NH, photon]
+        particleId = Decide(scores[0], scores[1], scores[2]);
+      }
+    }
+
+    // ---- write the verdict as the cluster ParticleId ----
+    PandoraContentApi::Cluster::Metadata metadata;
+    metadata.m_particleId = particleId;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::Cluster::AlterMetadata(*this, pCluster, metadata));
+  }
+
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ClusterNeutralPidAlgorithm::LoadModel() {
+  if (m_modelPath.empty()) {
+    std::cout << "ClusterNeutralPidAlgorithm: ModelPath is empty." << std::endl;
+    return STATUS_CODE_INVALID_PARAMETER;
+  }
+  m_session.reset(new OnnxSession(m_modelPath));
+  if (!m_session->IsValid())
+    return STATUS_CODE_FAILURE;
+
+  if (m_session->InputCount() != 3 || m_session->OutputCount() != 1) {
+    std::cout << "ClusterNeutralPidAlgorithm: expected 3 inputs and 1 output." << std::endl;
+    return STATUS_CODE_FAILURE;
+  }
+
+  const std::vector<std::int64_t> tokensShape = m_session->InputShape(0);
+  if (tokensShape.size() == 3 && tokensShape[1] > 0 &&
+      tokensShape[1] != static_cast<std::int64_t>(m_maxTokens)) {
+    std::cout << "ClusterNeutralPidAlgorithm: model MAX_TOKENS=" << tokensShape[1]
+              << " != configured budget sum " << m_maxTokens << "." << std::endl;
+    return STATUS_CODE_FAILURE;
+  }
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ClusterNeutralPidAlgorithm::ReadSettings(const TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+      XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "W0", m_w0));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "ConeLateralMm", m_coneLateralMm));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetOwnEcal", m_budgetOwnEcal));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetOtherEcal", m_budgetOtherEcal));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetHcal", m_budgetHcal));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetTrack", m_budgetTrack));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "PhotonThreshold", m_photonThreshold));
+
+  m_maxTokens = m_budgetOwnEcal + m_budgetOtherEcal + m_budgetHcal + m_budgetTrack;
+  return this->LoadModel();
+}
+
+} // namespace lc_content

--- a/src/MLInference/OnnxSession.cc
+++ b/src/MLInference/OnnxSession.cc
@@ -21,7 +21,7 @@ struct OnnxSession::Impl {
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-OnnxSession::OnnxSession(const std::string &modelPath, const int intraOpThreads) : m_impl(new Impl()) {
+OnnxSession::OnnxSession(const std::string& modelPath, const int intraOpThreads) : m_impl(new Impl()) {
   try {
     Ort::SessionOptions options;
     options.SetIntraOpNumThreads(intraOpThreads);
@@ -34,7 +34,7 @@ OnnxSession::OnnxSession(const std::string &modelPath, const int intraOpThreads)
       m_impl->outputNames.emplace_back(m_impl->session->GetOutputNameAllocated(i, allocator).get());
 
     m_impl->valid = true;
-  } catch (const Ort::Exception &exception) {
+  } catch (const Ort::Exception& exception) {
     std::cout << "OnnxSession: failed to load '" << modelPath << "' (" << exception.what() << ")." << std::endl;
     m_impl->valid = false;
   }
@@ -52,9 +52,9 @@ std::size_t OnnxSession::InputCount() const { return m_impl->inputNames.size(); 
 
 std::size_t OnnxSession::OutputCount() const { return m_impl->outputNames.size(); }
 
-const std::vector<std::string> &OnnxSession::InputNames() const { return m_impl->inputNames; }
+const std::vector<std::string>& OnnxSession::InputNames() const { return m_impl->inputNames; }
 
-const std::vector<std::string> &OnnxSession::OutputNames() const { return m_impl->outputNames; }
+const std::vector<std::string>& OnnxSession::OutputNames() const { return m_impl->outputNames; }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -67,7 +67,7 @@ std::vector<std::int64_t> OnnxSession::InputShape(const std::size_t index) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-std::vector<std::vector<float>> OnnxSession::Run(const std::vector<Input> &inputs) const {
+std::vector<std::vector<float>> OnnxSession::Run(const std::vector<Input>& inputs) const {
   if (!m_impl->valid)
     return {};
 
@@ -75,47 +75,49 @@ std::vector<std::vector<float>> OnnxSession::Run(const std::vector<Input> &input
   // const_cast is safe (the caller owns const data for the duration of the call).
   std::vector<Ort::Value> ortInputs;
   ortInputs.reserve(inputs.size());
-  for (const Input &input : inputs) {
+  for (const Input& input : inputs) {
     std::size_t nElements = 1;
     for (const std::int64_t dim : input.shape)
       nElements *= static_cast<std::size_t>(dim);
 
     switch (input.type) {
     case Input::Type::Float:
-      ortInputs.emplace_back(Ort::Value::CreateTensor<float>(m_impl->mem, const_cast<float *>(static_cast<const float *>(input.data)),
+      ortInputs.emplace_back(Ort::Value::CreateTensor<float>(m_impl->mem,
+                                                             const_cast<float*>(static_cast<const float*>(input.data)),
                                                              nElements, input.shape.data(), input.shape.size()));
       break;
     case Input::Type::Int64:
-      ortInputs.emplace_back(
-          Ort::Value::CreateTensor<std::int64_t>(m_impl->mem, const_cast<std::int64_t *>(static_cast<const std::int64_t *>(input.data)),
-                                                 nElements, input.shape.data(), input.shape.size()));
+      ortInputs.emplace_back(Ort::Value::CreateTensor<std::int64_t>(
+          m_impl->mem, const_cast<std::int64_t*>(static_cast<const std::int64_t*>(input.data)), nElements,
+          input.shape.data(), input.shape.size()));
       break;
     case Input::Type::Bool:
-      ortInputs.emplace_back(Ort::Value::CreateTensor<bool>(m_impl->mem, const_cast<bool *>(static_cast<const bool *>(input.data)),
+      ortInputs.emplace_back(Ort::Value::CreateTensor<bool>(m_impl->mem,
+                                                            const_cast<bool*>(static_cast<const bool*>(input.data)),
                                                             nElements, input.shape.data(), input.shape.size()));
       break;
     }
   }
 
-  std::vector<const char *> inputNamesC, outputNamesC;
-  for (const std::string &name : m_impl->inputNames)
+  std::vector<const char*> inputNamesC, outputNamesC;
+  for (const std::string& name : m_impl->inputNames)
     inputNamesC.push_back(name.c_str());
-  for (const std::string &name : m_impl->outputNames)
+  for (const std::string& name : m_impl->outputNames)
     outputNamesC.push_back(name.c_str());
 
   try {
-    auto outputs = m_impl->session->Run(Ort::RunOptions{nullptr}, inputNamesC.data(), ortInputs.data(), ortInputs.size(),
-                                        outputNamesC.data(), outputNamesC.size());
+    auto outputs = m_impl->session->Run(Ort::RunOptions{nullptr}, inputNamesC.data(), ortInputs.data(),
+                                        ortInputs.size(), outputNamesC.data(), outputNamesC.size());
 
     std::vector<std::vector<float>> result;
     result.reserve(outputs.size());
-    for (Ort::Value &output : outputs) {
+    for (Ort::Value& output : outputs) {
       const std::size_t count = output.GetTensorTypeAndShapeInfo().GetElementCount();
-      const float *const data = output.GetTensorMutableData<float>();
+      const float* const data = output.GetTensorMutableData<float>();
       result.emplace_back(data, data + count);
     }
     return result;
-  } catch (const Ort::Exception &exception) {
+  } catch (const Ort::Exception& exception) {
     std::cout << "OnnxSession: inference failed (" << exception.what() << ")." << std::endl;
     return {};
   }

--- a/src/MLInference/OnnxSession.cc
+++ b/src/MLInference/OnnxSession.cc
@@ -1,0 +1,124 @@
+/**
+ *  @file   LCContent/src/MLInference/OnnxSession.cc
+ *
+ *  @brief  Implementation of OnnxSession -- the ONLY translation unit that includes onnxruntime.
+ */
+#include "MLInference/OnnxSession.h"
+
+#include <onnxruntime_cxx_api.h>
+
+#include <iostream>
+
+namespace lc_content {
+
+struct OnnxSession::Impl {
+  Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "OnnxSession"};
+  Ort::MemoryInfo mem{Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault)};
+  std::unique_ptr<Ort::Session> session;
+  std::vector<std::string> inputNames, outputNames;
+  bool valid = false;
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+OnnxSession::OnnxSession(const std::string &modelPath, const int intraOpThreads) : m_impl(new Impl()) {
+  try {
+    Ort::SessionOptions options;
+    options.SetIntraOpNumThreads(intraOpThreads);
+    m_impl->session.reset(new Ort::Session(m_impl->env, modelPath.c_str(), options)); // throws on bad path
+
+    Ort::AllocatorWithDefaultOptions allocator;
+    for (std::size_t i = 0; i < m_impl->session->GetInputCount(); ++i)
+      m_impl->inputNames.emplace_back(m_impl->session->GetInputNameAllocated(i, allocator).get());
+    for (std::size_t i = 0; i < m_impl->session->GetOutputCount(); ++i)
+      m_impl->outputNames.emplace_back(m_impl->session->GetOutputNameAllocated(i, allocator).get());
+
+    m_impl->valid = true;
+  } catch (const Ort::Exception &exception) {
+    std::cout << "OnnxSession: failed to load '" << modelPath << "' (" << exception.what() << ")." << std::endl;
+    m_impl->valid = false;
+  }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+OnnxSession::~OnnxSession() = default;
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool OnnxSession::IsValid() const { return m_impl->valid; }
+
+std::size_t OnnxSession::InputCount() const { return m_impl->inputNames.size(); }
+
+std::size_t OnnxSession::OutputCount() const { return m_impl->outputNames.size(); }
+
+const std::vector<std::string> &OnnxSession::InputNames() const { return m_impl->inputNames; }
+
+const std::vector<std::string> &OnnxSession::OutputNames() const { return m_impl->outputNames; }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+std::vector<std::int64_t> OnnxSession::InputShape(const std::size_t index) const {
+  if (!m_impl->valid || index >= m_impl->session->GetInputCount())
+    return {};
+
+  return m_impl->session->GetInputTypeInfo(index).GetTensorTypeAndShapeInfo().GetShape();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+std::vector<std::vector<float>> OnnxSession::Run(const std::vector<Input> &inputs) const {
+  if (!m_impl->valid)
+    return {};
+
+  // ONNX Runtime's CreateTensor takes a non-const data pointer but does not modify inputs; the
+  // const_cast is safe (the caller owns const data for the duration of the call).
+  std::vector<Ort::Value> ortInputs;
+  ortInputs.reserve(inputs.size());
+  for (const Input &input : inputs) {
+    std::size_t nElements = 1;
+    for (const std::int64_t dim : input.shape)
+      nElements *= static_cast<std::size_t>(dim);
+
+    switch (input.type) {
+    case Input::Type::Float:
+      ortInputs.emplace_back(Ort::Value::CreateTensor<float>(m_impl->mem, const_cast<float *>(static_cast<const float *>(input.data)),
+                                                             nElements, input.shape.data(), input.shape.size()));
+      break;
+    case Input::Type::Int64:
+      ortInputs.emplace_back(
+          Ort::Value::CreateTensor<std::int64_t>(m_impl->mem, const_cast<std::int64_t *>(static_cast<const std::int64_t *>(input.data)),
+                                                 nElements, input.shape.data(), input.shape.size()));
+      break;
+    case Input::Type::Bool:
+      ortInputs.emplace_back(Ort::Value::CreateTensor<bool>(m_impl->mem, const_cast<bool *>(static_cast<const bool *>(input.data)),
+                                                            nElements, input.shape.data(), input.shape.size()));
+      break;
+    }
+  }
+
+  std::vector<const char *> inputNamesC, outputNamesC;
+  for (const std::string &name : m_impl->inputNames)
+    inputNamesC.push_back(name.c_str());
+  for (const std::string &name : m_impl->outputNames)
+    outputNamesC.push_back(name.c_str());
+
+  try {
+    auto outputs = m_impl->session->Run(Ort::RunOptions{nullptr}, inputNamesC.data(), ortInputs.data(), ortInputs.size(),
+                                        outputNamesC.data(), outputNamesC.size());
+
+    std::vector<std::vector<float>> result;
+    result.reserve(outputs.size());
+    for (Ort::Value &output : outputs) {
+      const std::size_t count = output.GetTensorTypeAndShapeInfo().GetElementCount();
+      const float *const data = output.GetTensorMutableData<float>();
+      result.emplace_back(data, data + count);
+    }
+    return result;
+  } catch (const Ort::Exception &exception) {
+    std::cout << "OnnxSession: inference failed (" << exception.what() << ")." << std::endl;
+    return {};
+  }
+}
+
+} // namespace lc_content

--- a/src/MLInference/SatelliteAssignmentOnnxAlgorithm.cc
+++ b/src/MLInference/SatelliteAssignmentOnnxAlgorithm.cc
@@ -1,0 +1,452 @@
+/**
+ *  @file   LCContent/src/MLInference/SatelliteAssignmentOnnxAlgorithm.cc
+ *
+ *  @brief  ONNX cluster-grouping satellite assignment (SPLIT policy).  Token set, feature layout
+ *          and pfo-indexing reproduce the model's training tokenisation.
+ */
+#include "Pandora/AlgorithmHeaders.h"
+#include "Api/PandoraContentApi.h"
+#include "Objects/Cluster.h"
+#include "Objects/CaloHit.h"
+#include "Objects/Track.h"
+
+#include "LCHelpers/VectorHelper.h"
+#include "MLInference/SatelliteAssignmentOnnxAlgorithm.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+using namespace pandora;
+
+namespace lc_content {
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+SatelliteAssignmentOnnxAlgorithm::~SatelliteAssignmentOnnxAlgorithm() = default;
+
+void SatelliteAssignmentOnnxAlgorithm::LoadModel() {
+  m_session.reset(new OnnxSession(m_modelPath));   // one intra-op thread; invalid on a bad path
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+SatelliteAssignmentOnnxAlgorithm::Hit SatelliteAssignmentOnnxAlgorithm::ExtractHit(const CaloHit *const pHit) {
+  Hit hit;
+  float r = 0.f, phi = 0.f, theta = 0.f;
+  pHit->GetPositionVector().GetSphericalCoordinates(r, phi, theta);   // a calo hit is never at the origin
+  hit.theta  = theta;
+  hit.phi    = phi;
+  hit.energy = pHit->GetInputEnergy();
+  hit.isEcal = (pHit->GetHadronicEnergy() <= 0.f);                    // ECAL hits carry no hadronic energy
+  hit.isCher = (pHit->GetHitType() == DRC_CHEREN);
+  hit.depth  = hit.isEcal ? static_cast<float>(pHit->GetLayer()) : SENT;  // ECAL layer index; SENT for HCAL
+  return hit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster *const pCluster, ClusterInfo &info) const {
+  CaloHitList caloHits;
+  pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHits);
+  if (caloHits.empty())
+    return false;
+
+  double sumX = 0., sumY = 0., sumZ = 0., sumE = 0.;
+  for (const CaloHit *const pHit : caloHits) {
+    const float energy = pHit->GetInputEnergy();
+    if (energy <= 0.f)
+      continue;
+    info.hits.push_back(ExtractHit(pHit));
+    const CartesianVector &position = pHit->GetPositionVector();
+    sumX += position.GetX() * energy;
+    sumY += position.GetY() * energy;
+    sumZ += position.GetZ() * energy;
+    sumE += energy;
+  }
+  if (info.hits.empty() || sumE <= 0.)
+    return false;
+
+  const CartesianVector centroid(static_cast<float>(sumX / sumE),
+                                 static_cast<float>(sumY / sumE),
+                                 static_cast<float>(sumZ / sumE));
+  if (centroid.GetMagnitude() <= std::numeric_limits<float>::epsilon())
+    return false;
+
+  info.pCluster    = pCluster;
+  info.centroidDir = centroid.GetUnitVector();
+
+  // any track reaching the calorimeter makes this a charged primary (track state taken there, no
+  // projection; no |p| cut -- matches the training tokenisation); the highest-momentum track is used
+  const Track *pBestTrack = nullptr;
+  float bestMomentum = 0.f;
+  for (const Track *const pTrack : pCluster->GetAssociatedTrackList()) {
+    if (!pTrack->ReachesCalorimeter())
+      continue;
+    const float momentum = pTrack->GetTrackStateAtCalorimeter().GetMomentum().GetMagnitude();
+    if (momentum > bestMomentum) {
+      bestMomentum = momentum;
+      pBestTrack   = pTrack;
+    }
+  }
+  if (pBestTrack) {
+    float r = 0.f, phi = 0.f, theta = 0.f;
+    pBestTrack->GetTrackStateAtCalorimeter().GetPosition().GetSphericalCoordinates(r, phi, theta);
+    info.hasTrack = true;
+    info.trkTheta = theta;
+    info.trkPhi   = phi;
+    info.trkP     = bestMomentum;
+  }
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+// The ONE place the model runs.  Emits the candidate's own hits (pfo 0) plus, for each in-cone
+// neighbour cluster, its top-K hits (and a track token if it is tracked) under a shared pfo index.
+// The ONNX graph returns one affinity logit per neighbour pfo; we sigmoid them and return one
+// NeighbourAff per neighbour (its cluster, whether it is tracked, and the affinity).
+
+bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
+    const std::vector<ClusterInfo> &clusters, const int candIndex,
+    std::vector<NeighbourAff> &out) const {
+  out.clear();
+  if (!m_session || !m_session->IsValid())
+    return false;
+
+  // Reference frame = candidate's energy-weighted centroid direction; all angles are relative to it.
+  const ClusterInfo &candidate = clusters[candIndex];
+  float r = 0.f, anchorPhi = 0.f, anchorTheta = 0.f;
+  candidate.centroidDir.GetSphericalCoordinates(r, anchorPhi, anchorTheta);
+
+  std::vector<float>   tokenData;
+  std::vector<int64_t> typeIds, pfoIds;
+
+  // A calo-hit token: [dTheta, dPhi, depth, ln E, isCher, isEcal].
+  auto addHit = [&](const Hit &hit, const int type, const int pfo) {
+    tokenData.push_back(hit.theta - anchorTheta);
+    tokenData.push_back(VectorHelper::deltaPhi(hit.phi, anchorPhi));
+    tokenData.push_back(hit.depth);
+    tokenData.push_back(std::log(std::max(hit.energy, 1e-9f)));
+    tokenData.push_back(hit.isCher ? 1.f : 0.f);
+    tokenData.push_back(hit.isEcal ? 1.f : 0.f);
+    typeIds.push_back(type);
+    pfoIds.push_back(pfo);
+  };
+
+  // A track token: the ln|p| carrier at the calorimeter; depth/cher/ecal are sentinels.
+  auto addTrack = [&](const ClusterInfo &cluster, const int pfo) {
+    tokenData.push_back(cluster.trkTheta - anchorTheta);
+    tokenData.push_back(VectorHelper::deltaPhi(cluster.trkPhi, anchorPhi));
+    tokenData.push_back(SENT);
+    tokenData.push_back(std::log(std::max(cluster.trkP, 1e-6f)));
+    tokenData.push_back(SENT);
+    tokenData.push_back(SENT);
+    typeIds.push_back(TYPE_TRACK);
+    pfoIds.push_back(pfo);
+  };
+
+  // Keep only the top-K hits by energy (dynamic sequence length -> no padding).
+  auto topByEnergy = [](std::vector<Hit> hits, const int k) {
+    if (static_cast<int>(hits.size()) > k) {
+      std::nth_element(hits.begin(), hits.begin() + k, hits.end(),
+                       [](const Hit &a, const Hit &b) { return a.energy > b.energy; });
+      hits.resize(static_cast<std::size_t>(k));
+    }
+    return hits;
+  };
+
+  // Own tokens live under pfo 0.
+  for (const Hit &hit : topByEnergy(candidate.hits, m_budgetOwn))
+    addHit(hit, TYPE_OWN, 0);
+
+  // Every in-cone neighbour (no cap on their number) gets a 1-based pfo index; the k-th neighbour
+  // maps to output slot k-1.
+  std::vector<std::pair<const Cluster *, bool>> neighbourOfPfo;   // per pfo: (cluster, hasTrack)
+  int pfo = 0;
+  for (int j = 0; j < static_cast<int>(clusters.size()); ++j) {
+    if (j == candIndex)
+      continue;
+    if (candidate.centroidDir.GetCosOpeningAngle(clusters[j].centroidDir) <= m_coneCos)
+      continue;
+
+    ++pfo;
+    const ClusterInfo &neighbour = clusters[j];
+    for (const Hit &hit : topByEnergy(neighbour.hits, m_budgetNbr))
+      addHit(hit, TYPE_OTHER, pfo);
+    if (neighbour.hasTrack)
+      addTrack(neighbour, pfo);
+
+    neighbourOfPfo.emplace_back(neighbour.pCluster, neighbour.hasTrack);
+  }
+
+  const int nNeighbours = pfo;
+  if (nNeighbours == 0)                                           // nothing in cone -> no affinities
+    return false;
+
+  // Pack the inputs (order matches the model's inputs) and run via the shared ONNX session.
+  const int64_t nTokens = static_cast<int64_t>(typeIds.size());
+  const std::vector<OnnxSession::Input> inputs = {
+      {{1, nTokens, N_FEAT}, OnnxSession::Input::Type::Float, tokenData.data()},
+      {{1, nTokens},         OnnxSession::Input::Type::Int64, typeIds.data()},
+      {{1, nTokens},         OnnxSession::Input::Type::Int64, pfoIds.data()},
+  };
+  const std::vector<std::vector<float>> outputs = m_session->Run(inputs);
+  if (outputs.empty() || outputs[0].size() < static_cast<std::size_t>(nNeighbours))
+    return false;                                                    // inference failed / short output
+
+  const std::vector<float> &logits = outputs[0];                     // length == nNeighbours (dynamic)
+  out.reserve(nNeighbours);
+  for (int k = 0; k < nNeighbours; ++k)                              // pfo k+1 -> output slot k
+    out.push_back({neighbourOfPfo[k].first, neighbourOfPfo[k].second,
+                   1.f / (1.f + std::exp(-logits[k]))});             // sigmoid
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+// Snapshot every cluster in the current list into a ClusterInfo (hits, centroid, track state).
+// Clusters BuildInfo rejects (no usable hits / degenerate centroid) are dropped.
+
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::BuildClusterCache(
+    std::vector<ClusterInfo> &clusters) const {
+  const ClusterList *pClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+      PandoraContentApi::GetCurrentList(*this, pClusterList));
+
+  for (const Cluster *const pCluster : *pClusterList) {
+    ClusterInfo info;
+    if (this->BuildInfo(pCluster, info))
+      clusters.push_back(std::move(info));
+  }
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// The merge candidates are the clusters whose charged/neutral fate this algorithm decides: available,
+// trackless, and not already flagged a photon.  A cluster with a calo-reaching track is a charged
+// primary (a target, never a candidate); photons are handled by the upstream photon-ID chain.
+
+void SatelliteAssignmentOnnxAlgorithm::CollectCandidates(
+    const std::vector<ClusterInfo> &clusters, std::vector<int> &candidates) const {
+  for (int i = 0; i < static_cast<int>(clusters.size()); ++i) {
+    const Cluster *const pCluster = clusters[i].pCluster;
+
+    const bool isCandidate = pCluster->IsAvailable() &&
+                             !clusters[i].hasTrack &&
+                             (PHOTON != pCluster->GetParticleId());
+    if (isCandidate)
+      candidates.push_back(i);
+  }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// SPLIT policy (unchanged, frozen): each candidate is merged into the TRACKED neighbour it most wants
+// to join, provided that affinity clears AffinityThreshold.  Trackless neighbours are ignored here
+// (they are the neutral pass's business).  Nothing is applied yet -- we only record child -> parent.
+
+void SatelliteAssignmentOnnxAlgorithm::PlanChargedMerges(
+    const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
+    const std::map<int, std::vector<NeighbourAff>> &affinities,
+    std::map<const Cluster *, const Cluster *> &chargedMerges) const {
+  for (const int i : candidates) {
+    const auto iter = affinities.find(i);
+    if (iter == affinities.end())                          // inference failed / no neighbour -> keep neutral
+      continue;
+
+    // Highest-affinity tracked neighbour.
+    const Cluster *pBestParent = nullptr;
+    float bestAffinity = -1.f;
+    for (const NeighbourAff &n : iter->second) {
+      if (n.hasTrack && n.affinity > bestAffinity) {
+        bestAffinity = n.affinity;
+        pBestParent  = n.pCluster;
+      }
+    }
+
+    const Cluster *const pCandidate = clusters[i].pCluster;
+    if (bestAffinity > m_affinityThreshold && pBestParent && pBestParent != pCandidate)
+      chargedMerges[pCandidate] = pBestParent;
+  }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// Union-find over neutral<->neutral affinities (transitive: A~B, B~C => one object).  Only clusters
+// that stayed neutral participate (those that went charged are frozen and excluded), and only neutral
+// neighbours are ever unioned -- a charged cluster is never a target.  Each resulting component is
+// emitted with its biggest cluster first, so ApplyNeutralGroups merges the rest into it.
+
+void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
+    const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
+    const std::map<int, std::vector<NeighbourAff>> &affinities,
+    const std::set<const Cluster *> &becameCharged,
+    std::vector<std::vector<const Cluster *>> &neutralGroups) const {
+  // Seed the disjoint-set with the surviving neutral clusters (each its own parent).
+  std::map<const Cluster *, const Cluster *> parent;
+  for (const int i : candidates) {
+    const Cluster *const pCluster = clusters[i].pCluster;
+    if (!becameCharged.count(pCluster))
+      parent[pCluster] = pCluster;
+  }
+
+  // Disjoint-set find with path-halving (only ever called on keys present in `parent`).
+  auto find = [&parent](const Cluster *x) {
+    while (parent[x] != x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  };
+
+  // Union each surviving candidate with its neutral neighbours whose affinity clears the threshold.
+  for (const int i : candidates) {
+    const Cluster *const pCandidate = clusters[i].pCluster;
+    if (!parent.count(pCandidate))                         // candidate went charged -> not in the set
+      continue;
+
+    const auto iter = affinities.find(i);
+    if (iter == affinities.end())
+      continue;
+
+    for (const NeighbourAff &n : iter->second) {
+      const bool isNeutralSurvivor = !n.hasTrack && parent.count(n.pCluster);
+      if (isNeutralSurvivor && n.affinity > m_neutralAffinityThreshold)
+        parent[find(pCandidate)] = find(n.pCluster);
+    }
+  }
+
+  // Collect components; keep only real groups (>= 2 members) and put the biggest cluster first.
+  std::map<const Cluster *, std::vector<const Cluster *>> components;
+  for (const auto &entry : parent)
+    components[find(entry.first)].push_back(entry.first);
+
+  const auto energy = [](const Cluster *c) {
+    return c->GetHadronicEnergy() + c->GetElectromagneticEnergy();
+  };
+  for (auto &entry : components) {
+    std::vector<const Cluster *> &members = entry.second;
+    if (members.size() < 2)
+      continue;
+
+    std::size_t repIdx = 0;
+    for (std::size_t k = 1; k < members.size(); ++k)
+      if (energy(members[k]) > energy(members[repIdx]))
+        repIdx = k;
+
+    std::swap(members[0], members[repIdx]);               // representative = biggest, merged INTO
+    neutralGroups.push_back(members);
+  }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// Execute the planned charged merges.  The parent is a tracked cluster (never itself a merge child),
+// so it cannot be stale here; a null/unavailable parent is skipped defensively.
+
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ApplyChargedMerges(
+    const std::map<const Cluster *, const Cluster *> &merges) const {
+  for (const auto &childParent : merges) {
+    const Cluster *const pParent = childParent.second;
+    if (!pParent || !pParent->IsAvailable())
+      continue;
+
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::MergeAndDeleteClusters(*this, pParent, childParent.first));
+  }
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// Execute the planned neutral groups: merge every non-representative member into the representative
+// (members[0]).  Groups are disjoint, so no member is ever touched twice and the representative is
+// never deleted.
+
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ApplyNeutralGroups(
+    const std::vector<std::vector<const Cluster *>> &groups) const {
+  for (const std::vector<const Cluster *> &members : groups) {
+    const Cluster *const pRep = members.front();
+
+    for (const Cluster *const pChild : members) {
+      if (pChild == pRep)
+        continue;
+
+      PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+          PandoraContentApi::MergeAndDeleteClusters(*this, pRep, pChild));
+    }
+  }
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::Run() {
+  if (!m_session || !m_session->IsValid())
+    return STATUS_CODE_FAILURE;
+
+  // Snapshot the clusters and pick the trackless non-photon candidates.
+  std::vector<ClusterInfo> clusters;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->BuildClusterCache(clusters));
+
+  std::vector<int> candidates;
+  this->CollectCandidates(clusters, candidates);
+
+  // Score each candidate ONCE: its affinity to every in-cone neighbour (charged and neutral alike).
+  // Both passes below read these same scores -- no second inference (matches the offline validation).
+  std::map<int, std::vector<NeighbourAff>> affinities;
+  for (const int i : candidates) {
+    std::vector<NeighbourAff> neighbours;
+    if (this->ComputeNeighbourAffinities(clusters, i, neighbours))
+      affinities.emplace(i, std::move(neighbours));
+  }
+
+  // Pass 1: plan the (frozen) charged merges; remember which candidates thereby became charged.
+  std::map<const Cluster *, const Cluster *> chargedMerges;
+  this->PlanChargedMerges(clusters, candidates, affinities, chargedMerges);
+
+  std::set<const Cluster *> becameCharged;
+  for (const auto &childParent : chargedMerges)
+    becameCharged.insert(childParent.first);
+
+  // Pass 2: plan the neutral<->neutral grouping among the clusters that stayed neutral.
+  std::vector<std::vector<const Cluster *>> neutralGroups;
+  if (m_groupNeutral)
+    this->PlanNeutralGroups(clusters, candidates, affinities, becameCharged, neutralGroups);
+
+  // Apply charged first (freezes the charged assignment), then neutral among the survivors.
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ApplyChargedMerges(chargedMerges));
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ApplyNeutralGroups(neutralGroups));
+
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+      XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath));               // required
+
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "AffinityThreshold", m_affinityThreshold));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "ConeHalfAngle", m_coneHalfAngle));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetOwn", m_budgetOwn));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "BudgetNeighbour", m_budgetNbr));
+
+  // 2nd pass: neutral<->neutral union-find grouping (defaults on / 0.72; see Grouping_Satellite_Findings.md)
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "GroupNeutral", m_groupNeutral));
+  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+      XmlHelper::ReadValue(xmlHandle, "NeutralAffinityThreshold", m_neutralAffinityThreshold));
+
+  m_coneCos = std::cos(m_coneHalfAngle);
+  this->LoadModel();
+  return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content

--- a/src/MLInference/SatelliteAssignmentOnnxAlgorithm.cc
+++ b/src/MLInference/SatelliteAssignmentOnnxAlgorithm.cc
@@ -4,11 +4,11 @@
  *  @brief  ONNX cluster-grouping satellite assignment (SPLIT policy).  Token set, feature layout
  *          and pfo-indexing reproduce the model's training tokenisation.
  */
-#include "Pandora/AlgorithmHeaders.h"
 #include "Api/PandoraContentApi.h"
-#include "Objects/Cluster.h"
 #include "Objects/CaloHit.h"
+#include "Objects/Cluster.h"
 #include "Objects/Track.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 #include "LCHelpers/VectorHelper.h"
 #include "MLInference/SatelliteAssignmentOnnxAlgorithm.h"
@@ -31,39 +31,39 @@ namespace lc_content {
 SatelliteAssignmentOnnxAlgorithm::~SatelliteAssignmentOnnxAlgorithm() = default;
 
 void SatelliteAssignmentOnnxAlgorithm::LoadModel() {
-  m_session.reset(new OnnxSession(m_modelPath));   // one intra-op thread; invalid on a bad path
+  m_session.reset(new OnnxSession(m_modelPath)); // one intra-op thread; invalid on a bad path
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-SatelliteAssignmentOnnxAlgorithm::Hit SatelliteAssignmentOnnxAlgorithm::ExtractHit(const CaloHit *const pHit) {
+SatelliteAssignmentOnnxAlgorithm::Hit SatelliteAssignmentOnnxAlgorithm::ExtractHit(const CaloHit* const pHit) {
   Hit hit;
   float r = 0.f, phi = 0.f, theta = 0.f;
-  pHit->GetPositionVector().GetSphericalCoordinates(r, phi, theta);   // a calo hit is never at the origin
-  hit.theta  = theta;
-  hit.phi    = phi;
+  pHit->GetPositionVector().GetSphericalCoordinates(r, phi, theta); // a calo hit is never at the origin
+  hit.theta = theta;
+  hit.phi = phi;
   hit.energy = pHit->GetInputEnergy();
-  hit.isEcal = (pHit->GetHadronicEnergy() <= 0.f);                    // ECAL hits carry no hadronic energy
+  hit.isEcal = (pHit->GetHadronicEnergy() <= 0.f); // ECAL hits carry no hadronic energy
   hit.isCher = (pHit->GetHitType() == DRC_CHEREN);
-  hit.depth  = hit.isEcal ? static_cast<float>(pHit->GetLayer()) : SENT;  // ECAL layer index; SENT for HCAL
+  hit.depth = hit.isEcal ? static_cast<float>(pHit->GetLayer()) : SENT; // ECAL layer index; SENT for HCAL
   return hit;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster *const pCluster, ClusterInfo &info) const {
+bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster* const pCluster, ClusterInfo& info) const {
   CaloHitList caloHits;
   pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHits);
   if (caloHits.empty())
     return false;
 
   double sumX = 0., sumY = 0., sumZ = 0., sumE = 0.;
-  for (const CaloHit *const pHit : caloHits) {
+  for (const CaloHit* const pHit : caloHits) {
     const float energy = pHit->GetInputEnergy();
     if (energy <= 0.f)
       continue;
     info.hits.push_back(ExtractHit(pHit));
-    const CartesianVector &position = pHit->GetPositionVector();
+    const CartesianVector& position = pHit->GetPositionVector();
     sumX += position.GetX() * energy;
     sumY += position.GetY() * energy;
     sumZ += position.GetZ() * energy;
@@ -72,26 +72,25 @@ bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster *const pCluster, 
   if (info.hits.empty() || sumE <= 0.)
     return false;
 
-  const CartesianVector centroid(static_cast<float>(sumX / sumE),
-                                 static_cast<float>(sumY / sumE),
+  const CartesianVector centroid(static_cast<float>(sumX / sumE), static_cast<float>(sumY / sumE),
                                  static_cast<float>(sumZ / sumE));
   if (centroid.GetMagnitude() <= std::numeric_limits<float>::epsilon())
     return false;
 
-  info.pCluster    = pCluster;
+  info.pCluster = pCluster;
   info.centroidDir = centroid.GetUnitVector();
 
   // any track reaching the calorimeter makes this a charged primary (track state taken there, no
   // projection; no |p| cut -- matches the training tokenisation); the highest-momentum track is used
-  const Track *pBestTrack = nullptr;
+  const Track* pBestTrack = nullptr;
   float bestMomentum = 0.f;
-  for (const Track *const pTrack : pCluster->GetAssociatedTrackList()) {
+  for (const Track* const pTrack : pCluster->GetAssociatedTrackList()) {
     if (!pTrack->ReachesCalorimeter())
       continue;
     const float momentum = pTrack->GetTrackStateAtCalorimeter().GetMomentum().GetMagnitude();
     if (momentum > bestMomentum) {
       bestMomentum = momentum;
-      pBestTrack   = pTrack;
+      pBestTrack = pTrack;
     }
   }
   if (pBestTrack) {
@@ -99,8 +98,8 @@ bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster *const pCluster, 
     pBestTrack->GetTrackStateAtCalorimeter().GetPosition().GetSphericalCoordinates(r, phi, theta);
     info.hasTrack = true;
     info.trkTheta = theta;
-    info.trkPhi   = phi;
-    info.trkP     = bestMomentum;
+    info.trkPhi = phi;
+    info.trkP = bestMomentum;
   }
   return true;
 }
@@ -112,23 +111,23 @@ bool SatelliteAssignmentOnnxAlgorithm::BuildInfo(const Cluster *const pCluster, 
 // The ONNX graph returns one affinity logit per neighbour pfo; we sigmoid them and return one
 // NeighbourAff per neighbour (its cluster, whether it is tracked, and the affinity).
 
-bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
-    const std::vector<ClusterInfo> &clusters, const int candIndex,
-    std::vector<NeighbourAff> &out) const {
+bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(const std::vector<ClusterInfo>& clusters,
+                                                                  const int candIndex,
+                                                                  std::vector<NeighbourAff>& out) const {
   out.clear();
   if (!m_session || !m_session->IsValid())
     return false;
 
   // Reference frame = candidate's energy-weighted centroid direction; all angles are relative to it.
-  const ClusterInfo &candidate = clusters[candIndex];
+  const ClusterInfo& candidate = clusters[candIndex];
   float r = 0.f, anchorPhi = 0.f, anchorTheta = 0.f;
   candidate.centroidDir.GetSphericalCoordinates(r, anchorPhi, anchorTheta);
 
-  std::vector<float>   tokenData;
+  std::vector<float> tokenData;
   std::vector<int64_t> typeIds, pfoIds;
 
   // A calo-hit token: [dTheta, dPhi, depth, ln E, isCher, isEcal].
-  auto addHit = [&](const Hit &hit, const int type, const int pfo) {
+  auto addHit = [&](const Hit& hit, const int type, const int pfo) {
     tokenData.push_back(hit.theta - anchorTheta);
     tokenData.push_back(VectorHelper::deltaPhi(hit.phi, anchorPhi));
     tokenData.push_back(hit.depth);
@@ -140,7 +139,7 @@ bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
   };
 
   // A track token: the ln|p| carrier at the calorimeter; depth/cher/ecal are sentinels.
-  auto addTrack = [&](const ClusterInfo &cluster, const int pfo) {
+  auto addTrack = [&](const ClusterInfo& cluster, const int pfo) {
     tokenData.push_back(cluster.trkTheta - anchorTheta);
     tokenData.push_back(VectorHelper::deltaPhi(cluster.trkPhi, anchorPhi));
     tokenData.push_back(SENT);
@@ -155,19 +154,19 @@ bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
   auto topByEnergy = [](std::vector<Hit> hits, const int k) {
     if (static_cast<int>(hits.size()) > k) {
       std::nth_element(hits.begin(), hits.begin() + k, hits.end(),
-                       [](const Hit &a, const Hit &b) { return a.energy > b.energy; });
+                       [](const Hit& a, const Hit& b) { return a.energy > b.energy; });
       hits.resize(static_cast<std::size_t>(k));
     }
     return hits;
   };
 
   // Own tokens live under pfo 0.
-  for (const Hit &hit : topByEnergy(candidate.hits, m_budgetOwn))
+  for (const Hit& hit : topByEnergy(candidate.hits, m_budgetOwn))
     addHit(hit, TYPE_OWN, 0);
 
   // Every in-cone neighbour (no cap on their number) gets a 1-based pfo index; the k-th neighbour
   // maps to output slot k-1.
-  std::vector<std::pair<const Cluster *, bool>> neighbourOfPfo;   // per pfo: (cluster, hasTrack)
+  std::vector<std::pair<const Cluster*, bool>> neighbourOfPfo; // per pfo: (cluster, hasTrack)
   int pfo = 0;
   for (int j = 0; j < static_cast<int>(clusters.size()); ++j) {
     if (j == candIndex)
@@ -176,8 +175,8 @@ bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
       continue;
 
     ++pfo;
-    const ClusterInfo &neighbour = clusters[j];
-    for (const Hit &hit : topByEnergy(neighbour.hits, m_budgetNbr))
+    const ClusterInfo& neighbour = clusters[j];
+    for (const Hit& hit : topByEnergy(neighbour.hits, m_budgetNbr))
       addHit(hit, TYPE_OTHER, pfo);
     if (neighbour.hasTrack)
       addTrack(neighbour, pfo);
@@ -186,25 +185,24 @@ bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
   }
 
   const int nNeighbours = pfo;
-  if (nNeighbours == 0)                                           // nothing in cone -> no affinities
+  if (nNeighbours == 0) // nothing in cone -> no affinities
     return false;
 
   // Pack the inputs (order matches the model's inputs) and run via the shared ONNX session.
   const int64_t nTokens = static_cast<int64_t>(typeIds.size());
   const std::vector<OnnxSession::Input> inputs = {
       {{1, nTokens, N_FEAT}, OnnxSession::Input::Type::Float, tokenData.data()},
-      {{1, nTokens},         OnnxSession::Input::Type::Int64, typeIds.data()},
-      {{1, nTokens},         OnnxSession::Input::Type::Int64, pfoIds.data()},
+      {{1, nTokens}, OnnxSession::Input::Type::Int64, typeIds.data()},
+      {{1, nTokens}, OnnxSession::Input::Type::Int64, pfoIds.data()},
   };
   const std::vector<std::vector<float>> outputs = m_session->Run(inputs);
   if (outputs.empty() || outputs[0].size() < static_cast<std::size_t>(nNeighbours))
-    return false;                                                    // inference failed / short output
+    return false; // inference failed / short output
 
-  const std::vector<float> &logits = outputs[0];                     // length == nNeighbours (dynamic)
+  const std::vector<float>& logits = outputs[0]; // length == nNeighbours (dynamic)
   out.reserve(nNeighbours);
-  for (int k = 0; k < nNeighbours; ++k)                              // pfo k+1 -> output slot k
-    out.push_back({neighbourOfPfo[k].first, neighbourOfPfo[k].second,
-                   1.f / (1.f + std::exp(-logits[k]))});             // sigmoid
+  for (int k = 0; k < nNeighbours; ++k) // pfo k+1 -> output slot k
+    out.push_back({neighbourOfPfo[k].first, neighbourOfPfo[k].second, 1.f / (1.f + std::exp(-logits[k]))}); // sigmoid
   return true;
 }
 
@@ -213,13 +211,11 @@ bool SatelliteAssignmentOnnxAlgorithm::ComputeNeighbourAffinities(
 // Snapshot every cluster in the current list into a ClusterInfo (hits, centroid, track state).
 // Clusters BuildInfo rejects (no usable hits / degenerate centroid) are dropped.
 
-pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::BuildClusterCache(
-    std::vector<ClusterInfo> &clusters) const {
-  const ClusterList *pClusterList = nullptr;
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      PandoraContentApi::GetCurrentList(*this, pClusterList));
+pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::BuildClusterCache(std::vector<ClusterInfo>& clusters) const {
+  const ClusterList* pClusterList = nullptr;
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
 
-  for (const Cluster *const pCluster : *pClusterList) {
+  for (const Cluster* const pCluster : *pClusterList) {
     ClusterInfo info;
     if (this->BuildInfo(pCluster, info))
       clusters.push_back(std::move(info));
@@ -232,14 +228,12 @@ pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::BuildClusterCache(
 // trackless, and not already flagged a photon.  A cluster with a calo-reaching track is a charged
 // primary (a target, never a candidate); photons are handled by the upstream photon-ID chain.
 
-void SatelliteAssignmentOnnxAlgorithm::CollectCandidates(
-    const std::vector<ClusterInfo> &clusters, std::vector<int> &candidates) const {
+void SatelliteAssignmentOnnxAlgorithm::CollectCandidates(const std::vector<ClusterInfo>& clusters,
+                                                         std::vector<int>& candidates) const {
   for (int i = 0; i < static_cast<int>(clusters.size()); ++i) {
-    const Cluster *const pCluster = clusters[i].pCluster;
+    const Cluster* const pCluster = clusters[i].pCluster;
 
-    const bool isCandidate = pCluster->IsAvailable() &&
-                             !clusters[i].hasTrack &&
-                             (PHOTON != pCluster->GetParticleId());
+    const bool isCandidate = pCluster->IsAvailable() && !clusters[i].hasTrack && (PHOTON != pCluster->GetParticleId());
     if (isCandidate)
       candidates.push_back(i);
   }
@@ -251,25 +245,25 @@ void SatelliteAssignmentOnnxAlgorithm::CollectCandidates(
 // (they are the neutral pass's business).  Nothing is applied yet -- we only record child -> parent.
 
 void SatelliteAssignmentOnnxAlgorithm::PlanChargedMerges(
-    const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
-    const std::map<int, std::vector<NeighbourAff>> &affinities,
-    std::map<const Cluster *, const Cluster *> &chargedMerges) const {
+    const std::vector<ClusterInfo>& clusters, const std::vector<int>& candidates,
+    const std::map<int, std::vector<NeighbourAff>>& affinities,
+    std::map<const Cluster*, const Cluster*>& chargedMerges) const {
   for (const int i : candidates) {
     const auto iter = affinities.find(i);
-    if (iter == affinities.end())                          // inference failed / no neighbour -> keep neutral
+    if (iter == affinities.end()) // inference failed / no neighbour -> keep neutral
       continue;
 
     // Highest-affinity tracked neighbour.
-    const Cluster *pBestParent = nullptr;
+    const Cluster* pBestParent = nullptr;
     float bestAffinity = -1.f;
-    for (const NeighbourAff &n : iter->second) {
+    for (const NeighbourAff& n : iter->second) {
       if (n.hasTrack && n.affinity > bestAffinity) {
         bestAffinity = n.affinity;
-        pBestParent  = n.pCluster;
+        pBestParent = n.pCluster;
       }
     }
 
-    const Cluster *const pCandidate = clusters[i].pCluster;
+    const Cluster* const pCandidate = clusters[i].pCluster;
     if (bestAffinity > m_affinityThreshold && pBestParent && pBestParent != pCandidate)
       chargedMerges[pCandidate] = pBestParent;
   }
@@ -282,20 +276,19 @@ void SatelliteAssignmentOnnxAlgorithm::PlanChargedMerges(
 // emitted with its biggest cluster first, so ApplyNeutralGroups merges the rest into it.
 
 void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
-    const std::vector<ClusterInfo> &clusters, const std::vector<int> &candidates,
-    const std::map<int, std::vector<NeighbourAff>> &affinities,
-    const std::set<const Cluster *> &becameCharged,
-    std::vector<std::vector<const Cluster *>> &neutralGroups) const {
+    const std::vector<ClusterInfo>& clusters, const std::vector<int>& candidates,
+    const std::map<int, std::vector<NeighbourAff>>& affinities, const std::set<const Cluster*>& becameCharged,
+    std::vector<std::vector<const Cluster*>>& neutralGroups) const {
   // Seed the disjoint-set with the surviving neutral clusters (each its own parent).
-  std::map<const Cluster *, const Cluster *> parent;
+  std::map<const Cluster*, const Cluster*> parent;
   for (const int i : candidates) {
-    const Cluster *const pCluster = clusters[i].pCluster;
+    const Cluster* const pCluster = clusters[i].pCluster;
     if (!becameCharged.count(pCluster))
       parent[pCluster] = pCluster;
   }
 
   // Disjoint-set find with path-halving (only ever called on keys present in `parent`).
-  auto find = [&parent](const Cluster *x) {
+  auto find = [&parent](const Cluster* x) {
     while (parent[x] != x) {
       parent[x] = parent[parent[x]];
       x = parent[x];
@@ -305,15 +298,15 @@ void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
 
   // Union each surviving candidate with its neutral neighbours whose affinity clears the threshold.
   for (const int i : candidates) {
-    const Cluster *const pCandidate = clusters[i].pCluster;
-    if (!parent.count(pCandidate))                         // candidate went charged -> not in the set
+    const Cluster* const pCandidate = clusters[i].pCluster;
+    if (!parent.count(pCandidate)) // candidate went charged -> not in the set
       continue;
 
     const auto iter = affinities.find(i);
     if (iter == affinities.end())
       continue;
 
-    for (const NeighbourAff &n : iter->second) {
+    for (const NeighbourAff& n : iter->second) {
       const bool isNeutralSurvivor = !n.hasTrack && parent.count(n.pCluster);
       if (isNeutralSurvivor && n.affinity > m_neutralAffinityThreshold)
         parent[find(pCandidate)] = find(n.pCluster);
@@ -321,15 +314,13 @@ void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
   }
 
   // Collect components; keep only real groups (>= 2 members) and put the biggest cluster first.
-  std::map<const Cluster *, std::vector<const Cluster *>> components;
-  for (const auto &entry : parent)
+  std::map<const Cluster*, std::vector<const Cluster*>> components;
+  for (const auto& entry : parent)
     components[find(entry.first)].push_back(entry.first);
 
-  const auto energy = [](const Cluster *c) {
-    return c->GetHadronicEnergy() + c->GetElectromagneticEnergy();
-  };
-  for (auto &entry : components) {
-    std::vector<const Cluster *> &members = entry.second;
+  const auto energy = [](const Cluster* c) { return c->GetHadronicEnergy() + c->GetElectromagneticEnergy(); };
+  for (auto& entry : components) {
+    std::vector<const Cluster*>& members = entry.second;
     if (members.size() < 2)
       continue;
 
@@ -338,7 +329,7 @@ void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
       if (energy(members[k]) > energy(members[repIdx]))
         repIdx = k;
 
-    std::swap(members[0], members[repIdx]);               // representative = biggest, merged INTO
+    std::swap(members[0], members[repIdx]); // representative = biggest, merged INTO
     neutralGroups.push_back(members);
   }
 }
@@ -347,15 +338,15 @@ void SatelliteAssignmentOnnxAlgorithm::PlanNeutralGroups(
 // Execute the planned charged merges.  The parent is a tracked cluster (never itself a merge child),
 // so it cannot be stale here; a null/unavailable parent is skipped defensively.
 
-pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ApplyChargedMerges(
-    const std::map<const Cluster *, const Cluster *> &merges) const {
-  for (const auto &childParent : merges) {
-    const Cluster *const pParent = childParent.second;
+pandora::StatusCode
+SatelliteAssignmentOnnxAlgorithm::ApplyChargedMerges(const std::map<const Cluster*, const Cluster*>& merges) const {
+  for (const auto& childParent : merges) {
+    const Cluster* const pParent = childParent.second;
     if (!pParent || !pParent->IsAvailable())
       continue;
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-        PandoraContentApi::MergeAndDeleteClusters(*this, pParent, childParent.first));
+                             PandoraContentApi::MergeAndDeleteClusters(*this, pParent, childParent.first));
   }
   return STATUS_CODE_SUCCESS;
 }
@@ -365,17 +356,16 @@ pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ApplyChargedMerges(
 // (members[0]).  Groups are disjoint, so no member is ever touched twice and the representative is
 // never deleted.
 
-pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ApplyNeutralGroups(
-    const std::vector<std::vector<const Cluster *>> &groups) const {
-  for (const std::vector<const Cluster *> &members : groups) {
-    const Cluster *const pRep = members.front();
+pandora::StatusCode
+SatelliteAssignmentOnnxAlgorithm::ApplyNeutralGroups(const std::vector<std::vector<const Cluster*>>& groups) const {
+  for (const std::vector<const Cluster*>& members : groups) {
+    const Cluster* const pRep = members.front();
 
-    for (const Cluster *const pChild : members) {
+    for (const Cluster* const pChild : members) {
       if (pChild == pRep)
         continue;
 
-      PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-          PandoraContentApi::MergeAndDeleteClusters(*this, pRep, pChild));
+      PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pRep, pChild));
     }
   }
   return STATUS_CODE_SUCCESS;
@@ -404,15 +394,15 @@ pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::Run() {
   }
 
   // Pass 1: plan the (frozen) charged merges; remember which candidates thereby became charged.
-  std::map<const Cluster *, const Cluster *> chargedMerges;
+  std::map<const Cluster*, const Cluster*> chargedMerges;
   this->PlanChargedMerges(clusters, candidates, affinities, chargedMerges);
 
-  std::set<const Cluster *> becameCharged;
-  for (const auto &childParent : chargedMerges)
+  std::set<const Cluster*> becameCharged;
+  for (const auto& childParent : chargedMerges)
     becameCharged.insert(childParent.first);
 
   // Pass 2: plan the neutral<->neutral grouping among the clusters that stayed neutral.
-  std::vector<std::vector<const Cluster *>> neutralGroups;
+  std::vector<std::vector<const Cluster*>> neutralGroups;
   if (m_groupNeutral)
     this->PlanNeutralGroups(clusters, candidates, affinities, becameCharged, neutralGroups);
 
@@ -427,21 +417,22 @@ pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::Run() {
 
 pandora::StatusCode SatelliteAssignmentOnnxAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
   PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath));               // required
+                           XmlHelper::ReadValue(xmlHandle, "ModelPath", m_modelPath)); // required
 
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "AffinityThreshold", m_affinityThreshold));
+                                  XmlHelper::ReadValue(xmlHandle, "AffinityThreshold", m_affinityThreshold));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "ConeHalfAngle", m_coneHalfAngle));
+                                  XmlHelper::ReadValue(xmlHandle, "ConeHalfAngle", m_coneHalfAngle));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetOwn", m_budgetOwn));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetOwn", m_budgetOwn));
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "BudgetNeighbour", m_budgetNbr));
+                                  XmlHelper::ReadValue(xmlHandle, "BudgetNeighbour", m_budgetNbr));
 
   // 2nd pass: neutral<->neutral union-find grouping (defaults on / 0.72; see Grouping_Satellite_Findings.md)
   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-      XmlHelper::ReadValue(xmlHandle, "GroupNeutral", m_groupNeutral));
-  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+                                  XmlHelper::ReadValue(xmlHandle, "GroupNeutral", m_groupNeutral));
+  PANDORA_RETURN_RESULT_IF_AND_IF(
+      STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
       XmlHelper::ReadValue(xmlHandle, "NeutralAffinityThreshold", m_neutralAffinityThreshold));
 
   m_coneCos = std::cos(m_coneHalfAngle);


### PR DESCRIPTION
Pandora algorithms for the particle flow reconstruction with the IDEA option 2 detector. This is designed to work on ECAL clusters built by HEP-FCC/k4RecCalorimeter#271 via `edm4hep::Cluster` to `pandora::Cluster` conversion using key4hep/k4GaudiPandora#26. HCAL clusters are built within the pandora, seeded by the input ECAL clusters. There are also 3 algorithms that use ML via ONNX inference (photon ID, satellite cluster merging, and photon energy regression).

A presentation related to the physics contents will take place in https://indico.cern.ch/event/1707528/#9-pandora-for-idea-updates

Expect a few more changes before ready-to-review (I currently retrieve HCAL dimensions via input configuration, but ideally this should be done via the Pandora geometry tool). Microscopic review can be done later, but one can already have a look at the macroscopic design, e.g., overall structure, etc.