### PR TITLE
Add an option to use the angular distance instead of cartesian for IsolatedHitMergingAlgorithm

### DIFF
--- a/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
+++ b/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
@@ -33,7 +33,7 @@ public:
     {
         const pandora::Cluster         *pCluster;    ///< Pointer to the cluster (nullptr if deleted)
         pandora::CartesianVector        centroid;    ///< Centroid at inner pseudo-layer
-        float                           energy;      ///< Cluster energy (possibly dual-readout corrected)
+        float                           energy;      ///< Cluster energy (raw or plugin-corrected hadronic)
         pandora::CartesianVector        direction;   ///< Cluster initial direction (for opening-angle preselection)
         bool                            isEm;        ///< Whether the cluster is identified as an EM shower
         bool                            isCharged;   ///< Whether the cluster has an associated track
@@ -73,7 +73,8 @@ private:
                                          float &distance) const;
 
     /**
-     *  @brief  Get the energy of a cluster, optionally using dual-readout corrections.
+     *  @brief  Get the energy of a cluster: raw hadronic energy, or the EnergyCorrections-plugin
+     *          corrected hadronic energy when UseCorrectedHadronicEnergy is set.
      *
      *  @param  pCluster  address of the cluster
      *  @param  energy    output energy
@@ -87,7 +88,7 @@ private:
     float                   m_maxRecombinationDistance;     ///< Max distance between calo hit and cluster to allow addition of hit
     float                   m_minCosOpeningAngle;           ///< Min cos(angle) between hit and cluster directions to allow addition of hit
 
-    bool                    m_useDualReadout;               ///< Whether to use dual-readout energy corrections (default: false)
+    bool                    m_useCorrectedHadronicEnergy;   ///< Use the plugin-corrected hadronic energy instead of raw GetHadronicEnergy() (default: false)
     bool                    m_ignorePhotons;                ///< Whether to ignore photons when merging isolated hits (default: false)
     bool                    m_ignoreCharged;                ///< Whether to ignore charged clusters when merging isolated hits (default: false)
     bool                    m_useAngularDistance;           ///< Whether to use angular (1-cos(angle)) distance instead of Cartesian (default: false)

--- a/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
+++ b/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
@@ -10,6 +10,8 @@
 
 #include "Pandora/Algorithm.h"
 
+#include <vector>
+
 namespace lc_content
 {
 
@@ -24,19 +26,59 @@ public:
      */
     IsolatedHitMergingAlgorithm();
 
+    /**
+     *  @brief  Per-cluster cached quantities to avoid recomputing inside the hit loop.
+     */
+    struct ClusterCache
+    {
+        const pandora::Cluster         *pCluster;    ///< Pointer to the cluster (nullptr if deleted)
+        pandora::CartesianVector        centroid;    ///< Centroid at inner pseudo-layer
+        float                           energy;      ///< Cluster energy (possibly dual-readout corrected)
+        pandora::CartesianVector        direction;   ///< Cluster initial direction (for opening-angle preselection)
+        bool                            isEm;        ///< Whether the cluster is identified as an EM shower
+        bool                            isCharged;   ///< Whether the cluster has an associated track
+
+        ClusterCache()
+            : pCluster(nullptr)
+            , centroid(0.f, 0.f, 0.f)
+            , energy(0.f)
+            , direction(0.f, 0.f, 1.f)
+            , isEm(false)
+            , isCharged(false)
+        {}
+    };
+
 private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
-     *  @brief  Get closest distance between a specified calo hit and a non-isolated hit in a specified cluster
-     * 
-     *  @param  pCluster address of the cluster
-     *  @param  pCaloHit address of the calo hit
-     * 
-     *  @return The closest distance between the calo hit and a non-isolated hit in the cluster
+     *  @brief  Build a cache of per-cluster quantities, optionally filtering photons.
+     *
+     *  @param  clusterVector   input cluster vector
+     *  @param  clusterCaches   output vector of ClusterCache entries
      */
-    float GetDistanceToHit(const pandora::Cluster *const pCluster, const pandora::CaloHit *const pCaloHit) const;
+    pandora::StatusCode BuildClusterCache(const pandora::ClusterVector &clusterVector,
+                                          std::vector<ClusterCache> &clusterCaches) const;
+
+    /**
+     *  @brief  Get distance between a calo hit and a cluster using precomputed cache.
+     *
+     *  @param  cache        precomputed cluster info
+     *  @param  pCaloHit     address of the calo hit
+     *  @param  distance     output: distance metric (angular 1-cosA or Cartesian mm)
+     */
+    pandora::StatusCode GetDistanceToHit(const ClusterCache &cache,
+                                         const pandora::CaloHit *const pCaloHit,
+                                         float &distance) const;
+
+    /**
+     *  @brief  Get the energy of a cluster, optionally using dual-readout corrections.
+     *
+     *  @param  pCluster  address of the cluster
+     *  @param  energy    output energy
+     */
+    pandora::StatusCode GetClusterEnergy(const pandora::Cluster *const pCluster, float &energy) const;
 
     bool                    m_shouldUseCurrentClusterList;  ///< Whether to use clusters from the current list in the algorithm
     pandora::StringVector   m_additionalClusterListNames;   ///< Additional cluster lists from which to consider clusters
@@ -44,6 +86,11 @@ private:
     unsigned int            m_minHitsInCluster;             ///< Min number of hits allowed in a cluster - smaller clusters will be split up
     float                   m_maxRecombinationDistance;     ///< Max distance between calo hit and cluster to allow addition of hit
     float                   m_minCosOpeningAngle;           ///< Min cos(angle) between hit and cluster directions to allow addition of hit
+
+    bool                    m_useDualReadout;               ///< Whether to use dual-readout energy corrections (default: false)
+    bool                    m_ignorePhotons;                ///< Whether to ignore photons when merging isolated hits (default: false)
+    bool                    m_ignoreCharged;                ///< Whether to ignore charged clusters when merging isolated hits (default: false)
+    bool                    m_useAngularDistance;           ///< Whether to use angular (1-cos(angle)) distance instead of Cartesian (default: false)
 };
 
 } // namespace lc_content

--- a/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
+++ b/include/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h
@@ -66,11 +66,9 @@ private:
      *
      *  @param  cache        precomputed cluster info
      *  @param  pCaloHit     address of the calo hit
-     *  @param  distance     output: distance metric (angular 1-cosA or Cartesian mm)
      */
-    pandora::StatusCode GetDistanceToHit(const ClusterCache &cache,
-                                         const pandora::CaloHit *const pCaloHit,
-                                         float &distance) const;
+    float GetDistanceToHit(const ClusterCache &cache,
+                           const pandora::CaloHit *const pCaloHit) const;
 
     /**
      *  @brief  Get the energy of a cluster: raw hadronic energy, or the EnergyCorrections-plugin

--- a/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
@@ -7,12 +7,14 @@
  */
 
 #include "Pandora/AlgorithmHeaders.h"
+#include "Pandora/PdgTable.h"
 
 #include "LCHelpers/SortingHelper.h"
 
 #include "LCTopologicalAssociation/IsolatedHitMergingAlgorithm.h"
 
 #include <algorithm>
+#include <cmath>
 
 using namespace pandora;
 
@@ -23,7 +25,11 @@ IsolatedHitMergingAlgorithm::IsolatedHitMergingAlgorithm() :
     m_shouldUseCurrentClusterList(true),
     m_minHitsInCluster(4),
     m_maxRecombinationDistance(250.f),
-    m_minCosOpeningAngle(0.f)
+    m_minCosOpeningAngle(0.f),
+    m_useDualReadout(false),
+    m_ignorePhotons(false),
+    m_ignoreCharged(false),
+    m_useAngularDistance(false)
 {
 }
 
@@ -64,11 +70,14 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
     ClusterVector clusterVector(clusterList.begin(), clusterList.end());
     std::sort(clusterVector.begin(), clusterVector.end(), SortingHelper::SortClustersByInnerLayer);
 
+    // Build cache for remaining clusters
+    std::vector<ClusterCache> clusterCaches;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->BuildClusterCache(clusterVector, clusterCaches));
 
     // FIRST PART - find "small" clusters, below threshold number of calo hits, delete them and associate hits with other clusters
-    for (ClusterVector::iterator iterI = clusterVector.begin(), iterIEnd = clusterVector.end(); iterI != iterIEnd; ++iterI)
+    for (std::size_t iClus = 0; iClus < clusterVector.size(); ++iClus)
     {
-        const Cluster *const pClusterToDelete = *iterI;
+        const Cluster *const pClusterToDelete = clusterVector[iClus];
 
         if (NULL == pClusterToDelete)
             continue;
@@ -85,7 +94,9 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
         pClusterToDelete->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
 
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pClusterToDelete));
-        *iterI = NULL;
+        // Null both the vector entry and the parallel cache entry.
+        clusterVector[iClus]          = NULL;
+        clusterCaches[iClus].pCluster = NULL;
 
         // Redistribute hits that used to be in cluster I amongst other clusters
         for (CaloHitList::const_iterator hitIter = caloHitList.begin(), hitIterEnd = caloHitList.end(); hitIter != hitIterEnd; ++hitIter)
@@ -97,25 +108,27 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
             float minDistance(m_maxRecombinationDistance);
 
             // Find the most appropriate cluster for this newly-available hit
-            for (ClusterVector::const_iterator iterJ = clusterVector.begin(), iterJEnd = clusterVector.end(); iterJ != iterJEnd; ++iterJ)
+            for (const ClusterCache &cache : clusterCaches)
             {
-                const Cluster *const pNewHostCluster = *iterJ;
-
-                if (NULL == pNewHostCluster)
+                if (!cache.pCluster)
                     continue;
 
-                if (pNewHostCluster->GetNCaloHits() < nCaloHits)
+                if (cache.pCluster->GetNCaloHits() < nCaloHits)
                     continue;
 
-                const float distance(this->GetDistanceToHit(pNewHostCluster, pCaloHit));
-                const float hostClusterEnergy(pNewHostCluster->GetHadronicEnergy());
+                if (m_ignoreCharged && cache.isCharged)
+                    continue;
+
+                float distance(std::numeric_limits<float>::max());
+                PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetDistanceToHit(cache, pCaloHit, distance));
 
                 // In event of equidistant host candidates, choose highest energy cluster
-                if ((distance < minDistance) || ((distance == minDistance) && (hostClusterEnergy > bestHostClusterEnergy)))
+                if ((distance < minDistance) ||
+                    (distance == minDistance && cache.energy > bestHostClusterEnergy))
                 {
                     minDistance = distance;
-                    pBestHostCluster = pNewHostCluster;
-                    bestHostClusterEnergy = hostClusterEnergy;
+                    pBestHostCluster = cache.pCluster;
+                    bestHostClusterEnergy = cache.energy;
                 }
             }
 
@@ -127,37 +140,39 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
     }
 
 
-    // SECOND PART - loop over the remaining available isolated hits, and associate them with other clusters
+    // SECOND PART - loop over isolated hits and associate each with the best cluster.
     const CaloHitList *pCaloHitList = NULL;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
 
-    for (CaloHitList::const_iterator hitIterI = pCaloHitList->begin(); hitIterI != pCaloHitList->end(); ++hitIterI)
+    for (CaloHitList::const_iterator hitIter = pCaloHitList->begin(); hitIter != pCaloHitList->end(); ++hitIter)
     {
-        const CaloHit *const pCaloHit = *hitIterI;
+        const CaloHit *const pCaloHit = *hitIter;
 
         if (!pCaloHit->IsIsolated() || !PandoraContentApi::IsAvailable(*this, pCaloHit))
             continue;
 
         const Cluster *pBestHostCluster(NULL);
-        float bestHostClusterEnergy(0.);
-        float minDistance(m_maxRecombinationDistance);
+        float bestHostClusterEnergy(0.f);
+        float minDistance(std::numeric_limits<float>::max());
 
-        // Find most appropriate cluster for this isolated hit
-        for (ClusterVector::const_iterator iterJ = clusterVector.begin(), iterJEnd = clusterVector.end(); iterJ != iterJEnd; ++iterJ)
+        for (const ClusterCache &cache : clusterCaches)
         {
-            const Cluster *const pCluster = *iterJ;
-
-            if (NULL == pCluster)
+            if (!cache.pCluster)
+                continue;
+            if (m_ignorePhotons && cache.isEm && !cache.isCharged)
+                continue;
+            if (m_ignoreCharged && cache.isCharged)
                 continue;
 
-            const float distance(this->GetDistanceToHit(pCluster, pCaloHit));
-            const float hostClusterEnergy(pCluster->GetHadronicEnergy());
+            float distance(m_maxRecombinationDistance);
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetDistanceToHit(cache, pCaloHit, distance));
 
-            if ((distance < minDistance) || ((distance == minDistance) && (hostClusterEnergy > bestHostClusterEnergy)))
+            if ((distance < minDistance) ||
+                (distance == minDistance && cache.energy > bestHostClusterEnergy))
             {
-                minDistance = distance;
-                pBestHostCluster = pCluster;
-                bestHostClusterEnergy = hostClusterEnergy;
+                minDistance          = distance;
+                pBestHostCluster     = cache.pCluster;
+                bestHostClusterEnergy = cache.energy;
             }
         }
 
@@ -172,28 +187,99 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float IsolatedHitMergingAlgorithm::GetDistanceToHit(const Cluster *const pCluster, const CaloHit *const pCaloHit) const
+StatusCode IsolatedHitMergingAlgorithm::BuildClusterCache(const ClusterVector &clusterVector,
+                                                          std::vector<ClusterCache> &clusterCaches) const
 {
-    // Apply simple preselection using cosine of opening angle between the hit and cluster directions
-    if (pCaloHit->GetExpectedDirection().GetCosOpeningAngle(pCluster->GetInitialDirection()) < m_minCosOpeningAngle)
-        return std::numeric_limits<float>::max();
+    clusterCaches.clear();
+    clusterCaches.reserve(clusterVector.size());
 
-    float minDistanceSquared(std::numeric_limits<float>::max());
-    const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
-    const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
-
-    for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
+    for (const Cluster *const pCluster : clusterVector)
     {
-        const float distanceSquared((pCluster->GetCentroid(iter->first) - hitPosition).GetMagnitudeSquared());
+        ClusterCache cache;
+        cache.pCluster = pCluster; // may be nullptr if already deleted in Part 1
 
-        if (distanceSquared < minDistanceSquared)
-            minDistanceSquared = distanceSquared;
+        if (pCluster)
+        {
+            cache.centroid  = pCluster->GetCentroid(pCluster->GetInnerPseudoLayer());
+            cache.direction = pCluster->GetInitialDirection();
+            cache.isCharged = !pCluster->GetAssociatedTrackList().empty();
+            cache.isEm      = pCluster->GetParticleId() == pandora::PHOTON;
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetClusterEnergy(pCluster, cache.energy));
+        }
+        else
+        {
+            cache.energy    = 0.f;
+            cache.isEm      = false;
+            cache.isCharged = false;
+        }
+
+        clusterCaches.push_back(cache);
     }
 
-    if (minDistanceSquared < std::numeric_limits<float>::max())
-        return std::sqrt(minDistanceSquared);
+    return STATUS_CODE_SUCCESS;
+}
 
-    return std::numeric_limits<float>::max();
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode IsolatedHitMergingAlgorithm::GetDistanceToHit(const ClusterCache &cache,
+                                                         const CaloHit *const pCaloHit,
+                                                         float &distance) const
+{
+    // Apply simple preselection using cosine of opening angle between the hit and cluster directions
+    if (pCaloHit->GetExpectedDirection().GetCosOpeningAngle(cache.direction) < m_minCosOpeningAngle)
+    {
+        distance = std::numeric_limits<float>::max();
+        return STATUS_CODE_SUCCESS;
+    }
+
+    const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
+    distance = std::numeric_limits<float>::max();
+
+    // Angular mode: use (1 - cosA) as the distance metric.
+    if (m_useAngularDistance)
+    {
+        float cosA = cache.centroid.GetCosOpeningAngle(hitPosition);
+        cosA = std::max(-1.f, std::min(1.f, cosA));
+        distance = 1.f - cosA;
+    }
+    else
+    {
+        const OrderedCaloHitList &orderedCaloHitList(cache.pCluster->GetOrderedCaloHitList());
+        float minDistanceSquared = std::numeric_limits<float>::max();
+
+        for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
+        {
+          const float distanceSquared = (cache.pCluster->GetCentroid(iter->first) - hitPosition).GetMagnitudeSquared();
+
+          if (distanceSquared < minDistanceSquared)
+              minDistanceSquared = distanceSquared;
+        }
+
+        distance = std::sqrt(minDistanceSquared);
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode IsolatedHitMergingAlgorithm::GetClusterEnergy(const Cluster *const pCluster, float &energy) const
+{
+    if (!m_useDualReadout)
+    {
+        energy = pCluster->GetHadronicEnergy();
+        return STATUS_CODE_SUCCESS;
+    }
+
+    const pandora::EnergyCorrections *const pEnergyCorrections(PandoraContentApi::GetPlugins(*this)->GetEnergyCorrections());
+    if (!pEnergyCorrections)
+        return STATUS_CODE_FAILURE;
+
+    float corrEm(0.f), corrHad(0.f);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, pEnergyCorrections->MakeEnergyCorrections(pCluster, corrEm, corrHad));
+    energy = corrHad;
+
+    return STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -214,6 +300,18 @@ StatusCode IsolatedHitMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MinCosOpeningAngle", m_minCosOpeningAngle));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseDualReadout", m_useDualReadout));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseAngularDistance", m_useAngularDistance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "IgnorePhotons", m_ignorePhotons));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "IgnoreCharged", m_ignoreCharged));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
@@ -119,8 +119,7 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
                 if (m_ignoreCharged && cache.isCharged)
                     continue;
 
-                float distance(std::numeric_limits<float>::max());
-                PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetDistanceToHit(cache, pCaloHit, distance));
+                float distance = GetDistanceToHit(cache, pCaloHit);
 
                 // In event of equidistant host candidates, choose highest energy cluster
                 if ((distance < minDistance) ||
@@ -144,10 +143,8 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
     const CaloHitList *pCaloHitList = NULL;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
 
-    for (CaloHitList::const_iterator hitIter = pCaloHitList->begin(); hitIter != pCaloHitList->end(); ++hitIter)
+    for (const auto* pCaloHit : *pCaloHitList)
     {
-        const CaloHit *const pCaloHit = *hitIter;
-
         if (!pCaloHit->IsIsolated() || !PandoraContentApi::IsAvailable(*this, pCaloHit))
             continue;
 
@@ -164,14 +161,13 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
             if (m_ignoreCharged && cache.isCharged)
                 continue;
 
-            float distance(m_maxRecombinationDistance);
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetDistanceToHit(cache, pCaloHit, distance));
+            float distance = GetDistanceToHit(cache, pCaloHit);
 
             if ((distance < minDistance) ||
                 (distance == minDistance && cache.energy > bestHostClusterEnergy))
             {
-                minDistance          = distance;
-                pBestHostCluster     = cache.pCluster;
+                minDistance           = distance;
+                pBestHostCluster      = cache.pCluster;
                 bestHostClusterEnergy = cache.energy;
             }
         }
@@ -221,19 +217,17 @@ StatusCode IsolatedHitMergingAlgorithm::BuildClusterCache(const ClusterVector &c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode IsolatedHitMergingAlgorithm::GetDistanceToHit(const ClusterCache &cache,
-                                                         const CaloHit *const pCaloHit,
-                                                         float &distance) const
+float IsolatedHitMergingAlgorithm::GetDistanceToHit(const ClusterCache &cache,
+                                                    const CaloHit *const pCaloHit) const
 {
     // Apply simple preselection using cosine of opening angle between the hit and cluster directions
     if (pCaloHit->GetExpectedDirection().GetCosOpeningAngle(cache.direction) < m_minCosOpeningAngle)
     {
-        distance = std::numeric_limits<float>::max();
-        return STATUS_CODE_SUCCESS;
+        return std::numeric_limits<float>::max();
     }
 
     const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
-    distance = std::numeric_limits<float>::max();
+    float distance = std::numeric_limits<float>::max();
 
     // Angular mode: use (1 - cosA) as the distance metric.
     if (m_useAngularDistance)
@@ -258,7 +252,7 @@ StatusCode IsolatedHitMergingAlgorithm::GetDistanceToHit(const ClusterCache &cac
         distance = std::sqrt(minDistanceSquared);
     }
 
-    return STATUS_CODE_SUCCESS;
+    return distance;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
@@ -153,7 +153,7 @@ StatusCode IsolatedHitMergingAlgorithm::Run()
 
         const Cluster *pBestHostCluster(NULL);
         float bestHostClusterEnergy(0.f);
-        float minDistance(std::numeric_limits<float>::max());
+        float minDistance(m_maxRecombinationDistance);
 
         for (const ClusterCache &cache : clusterCaches)
         {

--- a/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/IsolatedHitMergingAlgorithm.cc
@@ -26,7 +26,7 @@ IsolatedHitMergingAlgorithm::IsolatedHitMergingAlgorithm() :
     m_minHitsInCluster(4),
     m_maxRecombinationDistance(250.f),
     m_minCosOpeningAngle(0.f),
-    m_useDualReadout(false),
+    m_useCorrectedHadronicEnergy(false),
     m_ignorePhotons(false),
     m_ignoreCharged(false),
     m_useAngularDistance(false)
@@ -265,7 +265,7 @@ StatusCode IsolatedHitMergingAlgorithm::GetDistanceToHit(const ClusterCache &cac
 
 StatusCode IsolatedHitMergingAlgorithm::GetClusterEnergy(const Cluster *const pCluster, float &energy) const
 {
-    if (!m_useDualReadout)
+    if (!m_useCorrectedHadronicEnergy)
     {
         energy = pCluster->GetHadronicEnergy();
         return STATUS_CODE_SUCCESS;
@@ -302,7 +302,7 @@ StatusCode IsolatedHitMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle
         "MinCosOpeningAngle", m_minCosOpeningAngle));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseDualReadout", m_useDualReadout));
+        "UseCorrectedHadronicEnergy", m_useCorrectedHadronicEnergy));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "UseAngularDistance", m_useAngularDistance));


### PR DESCRIPTION
Add an option to use the angular distance instead of cartesian for `IsolatedHitMergingAlgorithm`. Stripped from #33 as `IsolatedHitMergingAlgorithm` is being used in CLD's [`PandoraSettingsDefault.xml`](https://github.com/key4hep/CLDConfig/blob/main/CLDConfig/PandoraSettingsCLD/PandoraSettingsDefault.xml).

Validated that the behavior is bit-by-bit identical when using the default values for the new options, using k4GaudiPandora's `run_Pandora_ttbar` CI workflow and the following comparison script (similar to the existing `compare-pfos.py` script, but Gaudi vs Gaudi instead marlin vs Gaudi).

<details>
   <summary>compare-gaudi-identical.py (click to expand)</summary>

```python
#!/usr/bin/env python
#
# Copyright (c) 2020-2024 Key4hep-Project.
#
# This file is part of Key4hep.
# See https://key4hep.github.io/key4hep-doc/ for further info.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
#

# A simple script to check that the Pandora output of two Gaudi files is
# identical, value-by-value. Intended to verify that a change (e.g. an
# LCContent commit) does not alter the reconstruction output at all.
#
# Note: two ROOT files are never byte-identical even for identical data
# (they embed per-write UUIDs/timestamps and compression can differ), so a
# raw `cmp` is meaningless. Instead we decode every collection and compare
# every data member with exact `==` (bit-exact for floats) and every
# relation by its ObjectID index, following the structure of compare-pfos.py.
import argparse
import sys
from podio.reading import get_reader

parser = argparse.ArgumentParser(
    description="Check that the Pandora output of two Gaudi files is identical"
)
parser.add_argument(
    "--file-before",
    default="output_pandora_ttbar_before.root",
    help="Gaudi output file produced before the change",
)
parser.add_argument(
    "--file-after",
    default="output_pandora_ttbar.root",
    help="Gaudi output file produced after the change",
)
parser.add_argument(
    "--vertices-collections",
    default=["GaudiPandoraStartVertices"],
    nargs="+",
    help="Vertices collections to compare",
)
parser.add_argument(
    "--cluster-collections",
    default=["GaudiPandoraClusters"],
    nargs="+",
    help="Cluster collections to compare",
)
parser.add_argument(
    "--recoparticle-collections",
    default=["GaudiPandoraPFOs"],
    nargs="+",
    help="Reconstructed particle collections to compare",
)

args = parser.parse_args()

reader_before = get_reader(args.file_before)
reader_after = get_reader(args.file_after)

events_before = reader_before.get("events")
events_after = reader_after.get("events")

assert len(events_before) == len(events_after), (
    f"Number of events differ: {len(events_before)} (before) "
    f"vs {len(events_after)} (after)"
)

for i, frame_before in enumerate(events_before):
    frame_after = events_after[i]

    for collection in args.vertices_collections:
        print(f'Checking vertices collection "{collection}" in event {i}')
        vertices_before = frame_before.get(collection)
        vertices_after = frame_after.get(collection)
        assert len(vertices_before) == len(vertices_after), (
            f"Number of vertices differ for {collection}: "
            f"{len(vertices_before)} vs {len(vertices_after)}"
        )
        for j, (vertex_before, vertex_after) in enumerate(
            zip(vertices_before, vertices_after)
        ):
            for attr in [
                "Type",
                "Chi2",
                "Ndf",
                "Position",
                "CovMatrix",
                "AlgorithmType",
            ]:
                assert (
                    getattr(vertex_before, f"get{attr}")()
                    == getattr(vertex_after, f"get{attr}")()
                ), f"{attr} differ for vertex {j}: {getattr(vertex_before, f'get{attr}')()} vs {getattr(vertex_after, f'get{attr}')()}"

            for vmember in [
                "Parameters",
            ]:
                assert list(getattr(vertex_before, f"get{vmember}")()) == list(
                    getattr(vertex_after, f"get{vmember}")()
                ), f"{vmember} differ for vertex {j}: {list(getattr(vertex_before, f'get{vmember}')())} vs {list(getattr(vertex_after, f'get{vmember}')())}"

            for relation in [
                "Particles",
            ]:
                assert [
                    elem.id().index
                    for elem in getattr(vertex_before, f"get{relation}")()
                ] == [
                    elem.id().index
                    for elem in getattr(vertex_after, f"get{relation}")()
                ], f"{relation} differ for vertex {j}"

    for collection in args.cluster_collections:
        print(f'Checking cluster collection "{collection}" in event {i}')
        clusters_before = frame_before.get(collection)
        clusters_after = frame_after.get(collection)
        assert len(clusters_before) == len(clusters_after), (
            f"Number of clusters differ for {collection}: "
            f"{len(clusters_before)} vs {len(clusters_after)}"
        )
        for j, (cluster_before, cluster_after) in enumerate(
            zip(clusters_before, clusters_after)
        ):
            for attr in [
                "Type",
                "Energy",
                "EnergyError",
                "Position",
                "PositionError",
                "ITheta",
                "Phi",
                "DirectionError",
            ]:
                assert (
                    getattr(cluster_before, f"get{attr}")()
                    == getattr(cluster_after, f"get{attr}")()
                ), f"{attr} differ for cluster {j}: {getattr(cluster_before, f'get{attr}')()} vs {getattr(cluster_after, f'get{attr}')()}"

            for vmember in [
                "ShapeParameters",
                "SubdetectorEnergies",
            ]:
                assert list(getattr(cluster_before, f"get{vmember}")()) == list(
                    getattr(cluster_after, f"get{vmember}")()
                ), f"{vmember} differ for cluster {j}: {list(getattr(cluster_before, f'get{vmember}')())} vs {list(getattr(cluster_after, f'get{vmember}')())}"

            for relation in [
                "Clusters",
                "Hits",
            ]:
                assert [
                    elem.id().index
                    for elem in getattr(cluster_before, f"get{relation}")()
                ] == [
                    elem.id().index
                    for elem in getattr(cluster_after, f"get{relation}")()
                ], f"{relation} differ for cluster {j}"

    for collection in args.recoparticle_collections:
        print(f'Checking reconstructed particle collection "{collection}" in event {i}')
        recos_before = frame_before.get(collection)
        recos_after = frame_after.get(collection)
        assert len(recos_before) == len(recos_after), (
            f"Number of reconstructed particles differ for {collection}: "
            f"{len(recos_before)} vs {len(recos_after)}"
        )
        for j, (reco_before, reco_after) in enumerate(zip(recos_before, recos_after)):
            for attr in [
                "PDG",
                "Energy",
                "Momentum",
                "ReferencePoint",
                "Charge",
                "Mass",
                "GoodnessOfPID",
                "CovMatrix",
            ]:
                assert (
                    getattr(reco_before, f"get{attr}")()
                    == getattr(reco_after, f"get{attr}")()
                ), f"{attr} differ for reco {j}: {getattr(reco_before, f'get{attr}')()} vs {getattr(reco_after, f'get{attr}')()}"

            for relation in [
                "DecayVertex",
            ]:
                assert (
                    getattr(reco_before, f"get{relation}")().id().index
                    == getattr(reco_after, f"get{relation}")().id().index
                ), f"{relation} differ for reco {j}"

            for relation in [
                "Clusters",
                "Tracks",
                "Particles",
            ]:
                assert [
                    elem.id().index for elem in getattr(reco_before, f"get{relation}")()
                ] == [
                    elem.id().index for elem in getattr(reco_after, f"get{relation}")()
                ], f"{relation} differ for reco {j}"

print(
    f"\nOK: the two files are identical over {len(events_before)} event(s) for "
    f"collections {args.vertices_collections + args.cluster_collections + args.recoparticle_collections}"
)
sys.exit(0)
```

</details>