### PR TITLE
Export PandoraMonitoring CMake dependency

### DIFF
--- a/cmake/LCContentConfig.cmake.in
+++ b/cmake/LCContentConfig.cmake.in
@@ -21,8 +21,10 @@ set(LCContent_LIBRARIES "@LCContent_LIBRARIES@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(PandoraSDK REQUIRED)
+if("@PANDORA_MONITORING@")
+    find_dependency(PandoraMonitoring REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/LCContentTargets.cmake")
 
 check_required_components(LCContent)
-


### PR DESCRIPTION
LCContent links `PandoraPFA::PandoraMonitoring` publicly when it is built with PANDORA_MONITORING enabled, but its package configuration only locates PandoraSDK. Use the existing build-time PANDORA_MONITORING option in the generated package configuration to locate PandoraMonitoring only when that public dependency is present.