### PR TITLE
Maia/theta energy

### DIFF
--- a/include/LCContent.h
+++ b/include/LCContent.h
@@ -55,6 +55,20 @@ public:
     static pandora::StatusCode RegisterNonLinearityEnergyCorrection(const pandora::Pandora &pandora, const std::string &name,
         const pandora::EnergyCorrectionType energyCorrectionType, const pandora::FloatVector &inputEnergyCorrectionPoints,
         const pandora::FloatVector &outputEnergyCorrectionPoints);
+
+    /**
+     *  @brief  Register the theta-energy non linearity energy correction plugin (note user side configuration) with pandora
+     *
+     *  @param  pandora the pandora instance with which to register content
+     *  @param  name the name/label associated with the energy correction plugin
+     *  @param  energyCorrectionType the energy correction type
+     *  @param  thetaBinEdges the theta bin edges for the 2D lookup
+     *  @param  energyBinEdges the energy bin edges for the 2D lookup
+     *  @param  scaleFactors the row-major correction factors for the 2D lookup
+     */
+    static pandora::StatusCode RegisterNonLinearityEnergyCorrection(const pandora::Pandora &pandora, const std::string &name,
+        const pandora::EnergyCorrectionType energyCorrectionType, const pandora::FloatVector &thetaBinEdges,
+        const pandora::FloatVector &energyBinEdges, const pandora::FloatVector &scaleFactors);
     
     /**
      *  @brief  Register the software compensation energy correction plugin (note user side configuration) with pandora

--- a/include/LCPlugins/LCEnergyCorrectionPlugins.h
+++ b/include/LCPlugins/LCEnergyCorrectionPlugins.h
@@ -10,6 +10,10 @@
 
 #include "Plugins/EnergyCorrectionsPlugin.h"
 
+#include <string>
+
+namespace pandora { class CartesianVector; }
+
 namespace lc_content
 {
 
@@ -19,6 +23,30 @@ namespace lc_content
 class LCEnergyCorrectionPlugins
 {
 public:
+    /**
+     *  @brief  Record a registered theta-energy correction table for direct candidate-energy evaluation
+     *
+     *  @param  name the name/label associated with the energy correction plugin
+     *  @param  energyCorrectionType the energy correction type
+     *  @param  thetaBinEdges the theta bin edges for the 2D lookup
+     *  @param  energyBinEdges the energy bin edges for the 2D lookup
+     *  @param  scaleFactors the row-major correction factors for the 2D lookup
+     */
+    static void RegisterThetaEnergyCorrection(const std::string &name, const pandora::EnergyCorrectionType energyCorrectionType,
+        const pandora::FloatVector &thetaBinEdges, const pandora::FloatVector &energyBinEdges, const pandora::FloatVector &scaleFactors);
+
+    /**
+     *  @brief  Evaluate the registered theta-energy correction for a supplied candidate energy
+     *
+     *  @param  energyCorrectionType the energy correction type
+     *  @param  direction the direction used to determine theta
+     *  @param  energy the candidate energy before theta-energy correction
+     *
+     *  @return corrected candidate energy, or the input energy if no matching theta-energy table is available
+     */
+    static float GetThetaEnergyCorrectedEnergy(const pandora::EnergyCorrectionType energyCorrectionType,
+        const pandora::CartesianVector &direction, const float energy);
+
     /**
      *   @brief  Correct cluster energy to account for non-linearities in calibration
      */

--- a/include/LCPlugins/LCEnergyCorrectionPlugins.h
+++ b/include/LCPlugins/LCEnergyCorrectionPlugins.h
@@ -33,12 +33,27 @@ public:
          */
         NonLinearityCorrection(const pandora::FloatVector &inputEnergyCorrectionPoints, const pandora::FloatVector &outputEnergyCorrectionPoints);
 
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  thetaBinEdges the theta bin edges for the 2D lookup
+         *  @param  energyBinEdges the energy bin edges for the 2D lookup
+         *  @param  scaleFactors the row-major correction factors for the 2D lookup
+         */
+        NonLinearityCorrection(const pandora::FloatVector &thetaBinEdges, const pandora::FloatVector &energyBinEdges,
+            const pandora::FloatVector &scaleFactors);
+
         pandora::StatusCode MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const;
 
     private:
         pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+        float GetCorrection(const float theta, const float energy) const;
+
+        bool                    m_useTwoDimensionalCorrection = false; ///< Whether to use theta-energy binning
         pandora::FloatVector m_inputEnergyCorrectionPoints; ///< The input energy points for energy correction
+        pandora::FloatVector m_thetaBinEdges;               ///< The theta bin edges for the 2D lookup
+        pandora::FloatVector m_energyBinEdges;              ///< The energy bin edges for the 2D lookup
         pandora::FloatVector m_energyCorrections;           ///< The energy correction factors
     };
 

--- a/include/LCPlugins/LCParticleIdPlugins.h
+++ b/include/LCPlugins/LCParticleIdPlugins.h
@@ -114,6 +114,7 @@ public:
         float        m_maxProfileDiscrepancy;           ///< Max shower profile discrepancy for fast electron id
         float        m_profileDiscrepancyForAutoId;     ///< Shower profile discrepancy for automatic fast electron selection
         float        m_maxResidualEOverP;               ///< Max absolute difference between unity and ratio em energy / track momentum
+        bool         m_useCorrectedElectromagneticEnergyForEOverP; ///< Whether to use corrected em energy for E/p checks
     };
 
     /**

--- a/include/LCTopologicalAssociation/ConeBasedMergingAlgorithm.h
+++ b/include/LCTopologicalAssociation/ConeBasedMergingAlgorithm.h
@@ -72,6 +72,7 @@ private:
     float           m_minDaughterHadronicEnergy;        ///< Minimum daughter hadronic energy for merging (unless chi2 criteria are met)
     float           m_maxTrackClusterChi;               ///< Max no. standard deviations between clusters and associated track energies
     float           m_maxTrackClusterDChi2;             ///< Max diff between chi2 using parent+daughter energies and that using only parent
+    bool            m_useCorrectedHadronicEnergyForTrackComparison; ///< Whether to use corrected hadronic energy in track checks
 
     float           m_minCosConeAngleWrtRadial;         ///< Min cosine of angle between cone and radial direction
     float           m_cosConeAngleWrtRadialCut1;        ///< 1st pair of cuts: Min cosine of angle between cone and radial direction

--- a/include/LCTopologicalAssociation/ProximityBasedMergingAlgorithm.h
+++ b/include/LCTopologicalAssociation/ProximityBasedMergingAlgorithm.h
@@ -62,6 +62,7 @@ private:
 
     float           m_maxTrackClusterChi;               ///< Max no. standard deviations between clusters and associated track energies
     float           m_maxTrackClusterDChi2;             ///< Max diff between chi2 using parent+daughter energies and that using only parent
+    bool            m_useCorrectedHadronicEnergyForTrackComparison; ///< Whether to use corrected hadronic energy in track checks
 
     unsigned int    m_nGenericDistanceLayers;           ///< Number of layers to examine when calculating generic distance between clusters
     float           m_maxGenericDistance;               ///< Max value of generic distance between two clusters for clusters to be merged

--- a/include/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.h
+++ b/include/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.h
@@ -47,6 +47,7 @@ private:
     unsigned int    m_maxSearchLayer;                   ///< Max pseudo layer to examine when calculating track-cluster distance
     float           m_parallelDistanceCut;              ///< Max allowed projection of track-hit separation along track direction
     float           m_minTrackClusterCosAngle;          ///< Min cos(angle) between track and cluster initial direction
+    bool            m_useCorrectedHadronicEnergyForTrackComparison; ///< Whether to use corrected hadronic energy for track-cluster energy tie-breaks
 };
 
 } // namespace lc_content

--- a/src/LCContent.cc
+++ b/src/LCContent.cc
@@ -242,6 +242,16 @@ pandora::StatusCode LCContent::RegisterNonLinearityEnergyCorrection(const pandor
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+pandora::StatusCode LCContent::RegisterNonLinearityEnergyCorrection(const pandora::Pandora &pandora, const std::string &name,
+    const pandora::EnergyCorrectionType energyCorrectionType, const pandora::FloatVector &thetaBinEdges,
+    const pandora::FloatVector &energyBinEdges, const pandora::FloatVector &scaleFactors)
+{
+    return PandoraApi::RegisterEnergyCorrectionPlugin(pandora, name, energyCorrectionType,
+        new lc_content::LCEnergyCorrectionPlugins::NonLinearityCorrection(thetaBinEdges, energyBinEdges, scaleFactors));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 pandora::StatusCode LCContent::RegisterSoftwareCompensationEnergyCorrection(const pandora::Pandora &pandora, const std::string &name,
     const lc_content::LCSoftwareCompensationParameters &parameters)
 {

--- a/src/LCContent.cc
+++ b/src/LCContent.cc
@@ -246,8 +246,14 @@ pandora::StatusCode LCContent::RegisterNonLinearityEnergyCorrection(const pandor
     const pandora::EnergyCorrectionType energyCorrectionType, const pandora::FloatVector &thetaBinEdges,
     const pandora::FloatVector &energyBinEdges, const pandora::FloatVector &scaleFactors)
 {
-    return PandoraApi::RegisterEnergyCorrectionPlugin(pandora, name, energyCorrectionType,
-        new lc_content::LCEnergyCorrectionPlugins::NonLinearityCorrection(thetaBinEdges, energyBinEdges, scaleFactors));
+    const pandora::StatusCode statusCode(PandoraApi::RegisterEnergyCorrectionPlugin(pandora, name, energyCorrectionType,
+        new lc_content::LCEnergyCorrectionPlugins::NonLinearityCorrection(thetaBinEdges, energyBinEdges, scaleFactors)));
+
+    if (pandora::STATUS_CODE_SUCCESS == statusCode)
+        lc_content::LCEnergyCorrectionPlugins::RegisterThetaEnergyCorrection(name, energyCorrectionType,
+            thetaBinEdges, energyBinEdges, scaleFactors);
+
+    return statusCode;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/LCPlugins/LCEnergyCorrectionPlugins.cc
+++ b/src/LCPlugins/LCEnergyCorrectionPlugins.cc
@@ -12,6 +12,8 @@
 
 #include "LCPlugins/LCEnergyCorrectionPlugins.h"
 
+#include <map>
+
 using namespace pandora;
 
 namespace lc_content
@@ -19,6 +21,33 @@ namespace lc_content
 
 namespace
 {
+
+typedef std::pair<std::string, EnergyCorrectionType> ThetaEnergyCorrectionKey;
+
+class ThetaEnergyCorrectionTable
+{
+public:
+    ThetaEnergyCorrectionTable() = default;
+
+    ThetaEnergyCorrectionTable(const FloatVector &thetaBinEdges, const FloatVector &energyBinEdges, const FloatVector &scaleFactors) :
+        m_thetaBinEdges(thetaBinEdges),
+        m_energyBinEdges(energyBinEdges),
+        m_scaleFactors(scaleFactors)
+    {
+    }
+
+    FloatVector m_thetaBinEdges;
+    FloatVector m_energyBinEdges;
+    FloatVector m_scaleFactors;
+};
+
+typedef std::map<ThetaEnergyCorrectionKey, ThetaEnergyCorrectionTable> ThetaEnergyCorrectionTableMap;
+
+ThetaEnergyCorrectionTableMap &GetThetaEnergyCorrectionTableMap()
+{
+    static ThetaEnergyCorrectionTableMap thetaEnergyCorrectionTableMap;
+    return thetaEnergyCorrectionTableMap;
+}
 
 bool IsStrictlyIncreasing(const FloatVector &values)
 {
@@ -51,7 +80,59 @@ int FindBin(const FloatVector &edges, const float value)
     return -1;
 }
 
+float GetCorrection(const FloatVector &thetaBinEdges, const FloatVector &energyBinEdges, const FloatVector &scaleFactors,
+    const float theta, const float energy)
+{
+    const int thetaBin(FindBin(thetaBinEdges, theta));
+    const int energyBin(FindBin(energyBinEdges, energy));
+
+    if ((thetaBin < 0) || (energyBin < 0))
+        return 1.f;
+
+    const unsigned int nEnergyBins(energyBinEdges.size() - 1);
+    return scaleFactors.at(static_cast<unsigned int>(thetaBin) * nEnergyBins + static_cast<unsigned int>(energyBin));
+}
+
 } // namespace
+
+void LCEnergyCorrectionPlugins::RegisterThetaEnergyCorrection(const std::string &name, const EnergyCorrectionType energyCorrectionType,
+    const FloatVector &thetaBinEdges, const FloatVector &energyBinEdges, const FloatVector &scaleFactors)
+{
+    if (!IsStrictlyIncreasing(thetaBinEdges) || !IsStrictlyIncreasing(energyBinEdges))
+        return;
+
+    const unsigned int nThetaBins(thetaBinEdges.size() - 1);
+    const unsigned int nEnergyBins(energyBinEdges.size() - 1);
+
+    if ((0 == nThetaBins) || (0 == nEnergyBins) || (nThetaBins * nEnergyBins != scaleFactors.size()))
+        return;
+
+    GetThetaEnergyCorrectionTableMap()[ThetaEnergyCorrectionKey(name, energyCorrectionType)] =
+        ThetaEnergyCorrectionTable(thetaBinEdges, energyBinEdges, scaleFactors);
+}
+
+//--------------------------------------------------------------------------
+
+float LCEnergyCorrectionPlugins::GetThetaEnergyCorrectedEnergy(const EnergyCorrectionType energyCorrectionType,
+    const CartesianVector &direction, const float energy)
+{
+    if (direction.GetMagnitude() < std::numeric_limits<float>::epsilon())
+        return energy;
+
+    const float cosTheta(std::max(-1.f, std::min(1.f, direction.GetCosOpeningAngle(CartesianVector(0.f, 0.f, 1.f)))));
+    const float theta(std::acos(cosTheta));
+
+    for (const ThetaEnergyCorrectionTableMap::value_type &mapEntry : GetThetaEnergyCorrectionTableMap())
+    {
+        if (mapEntry.first.second != energyCorrectionType)
+            continue;
+
+        const ThetaEnergyCorrectionTable &table(mapEntry.second);
+        return energy * GetCorrection(table.m_thetaBinEdges, table.m_energyBinEdges, table.m_scaleFactors, theta, energy);
+    }
+
+    return energy;
+}
 
 LCEnergyCorrectionPlugins::NonLinearityCorrection::NonLinearityCorrection(const FloatVector &inputEnergyCorrectionPoints,
         const FloatVector &outputEnergyCorrectionPoints) :

--- a/src/LCPlugins/LCEnergyCorrectionPlugins.cc
+++ b/src/LCPlugins/LCEnergyCorrectionPlugins.cc
@@ -17,6 +17,42 @@ using namespace pandora;
 namespace lc_content
 {
 
+namespace
+{
+
+bool IsStrictlyIncreasing(const FloatVector &values)
+{
+    if (values.size() < 2)
+        return false;
+
+    for (unsigned int i = 1; i < values.size(); ++i)
+    {
+        if (values.at(i) <= values.at(i - 1))
+            return false;
+    }
+
+    return true;
+}
+
+int FindBin(const FloatVector &edges, const float value)
+{
+    if (edges.size() < 2)
+        return -1;
+
+    if ((value < edges.front()) || (value >= edges.back()))
+        return -1;
+
+    for (unsigned int i = 0; i + 1 < edges.size(); ++i)
+    {
+        if ((edges.at(i) <= value) && (value < edges.at(i + 1)))
+            return static_cast<int>(i);
+    }
+
+    return -1;
+}
+
+} // namespace
+
 LCEnergyCorrectionPlugins::NonLinearityCorrection::NonLinearityCorrection(const FloatVector &inputEnergyCorrectionPoints,
         const FloatVector &outputEnergyCorrectionPoints) :
     m_inputEnergyCorrectionPoints(inputEnergyCorrectionPoints)
@@ -43,8 +79,43 @@ LCEnergyCorrectionPlugins::NonLinearityCorrection::NonLinearityCorrection(const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-pandora::StatusCode LCEnergyCorrectionPlugins::NonLinearityCorrection::MakeEnergyCorrections(const pandora::Cluster *const /*const pCluster*/, float &correctedEnergy) const
+LCEnergyCorrectionPlugins::NonLinearityCorrection::NonLinearityCorrection(const FloatVector &thetaBinEdges, const FloatVector &energyBinEdges,
+        const FloatVector &scaleFactors) :
+    m_useTwoDimensionalCorrection(true),
+    m_thetaBinEdges(thetaBinEdges),
+    m_energyBinEdges(energyBinEdges),
+    m_energyCorrections(scaleFactors)
 {
+    if (!IsStrictlyIncreasing(m_thetaBinEdges) || !IsStrictlyIncreasing(m_energyBinEdges))
+        throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
+
+    const unsigned int nThetaBins(m_thetaBinEdges.size() - 1);
+    const unsigned int nEnergyBins(m_energyBinEdges.size() - 1);
+
+    if ((0 == nThetaBins) || (0 == nEnergyBins) || (nThetaBins * nEnergyBins != m_energyCorrections.size()))
+        throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+pandora::StatusCode LCEnergyCorrectionPlugins::NonLinearityCorrection::MakeEnergyCorrections(const pandora::Cluster *const pCluster, float &correctedEnergy) const
+{
+    if (m_useTwoDimensionalCorrection)
+    {
+        if (NULL == pCluster)
+            return pandora::STATUS_CODE_SUCCESS;
+
+        const CartesianVector &clusterDirection(pCluster->GetFitToAllHitsResult().IsFitSuccessful() ?
+            pCluster->GetFitToAllHitsResult().GetDirection() : pCluster->GetInitialDirection());
+
+        if (clusterDirection.GetMagnitude() < std::numeric_limits<float>::epsilon())
+            return pandora::STATUS_CODE_SUCCESS;
+
+        const float cosTheta(std::max(-1.f, std::min(1.f, clusterDirection.GetCosOpeningAngle(CartesianVector(0.f, 0.f, 1.f)))));
+        correctedEnergy *= this->GetCorrection(std::acos(cosTheta), correctedEnergy);
+        return pandora::STATUS_CODE_SUCCESS;
+    }
+
     const unsigned int nEnergyBins(m_energyCorrections.size());
 
     if (0 == nEnergyBins)
@@ -84,6 +155,20 @@ pandora::StatusCode LCEnergyCorrectionPlugins::NonLinearityCorrection::MakeEnerg
 pandora::StatusCode LCEnergyCorrectionPlugins::NonLinearityCorrection::ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/)
 {
     return pandora::STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LCEnergyCorrectionPlugins::NonLinearityCorrection::GetCorrection(const float theta, const float energy) const
+{
+    const int thetaBin(FindBin(m_thetaBinEdges, theta));
+    const int energyBin(FindBin(m_energyBinEdges, energy));
+
+    if ((thetaBin < 0) || (energyBin < 0))
+        return 1.f;
+
+    const unsigned int nEnergyBins(m_energyBinEdges.size() - 1);
+    return m_energyCorrections.at(static_cast<unsigned int>(thetaBin) * nEnergyBins + static_cast<unsigned int>(energyBin));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/LCPlugins/LCParticleIdPlugins.cc
+++ b/src/LCPlugins/LCParticleIdPlugins.cc
@@ -347,7 +347,8 @@ LCParticleIdPlugins::LCElectronId::LCElectronId() :
     m_maxProfileStart(4.5f),
     m_maxProfileDiscrepancy(0.6f),
     m_profileDiscrepancyForAutoId(0.5f),
-    m_maxResidualEOverP(0.2f)
+    m_maxResidualEOverP(0.2f),
+    m_useCorrectedElectromagneticEnergyForEOverP(false)
 {
 }
 
@@ -384,7 +385,9 @@ bool LCParticleIdPlugins::LCElectronId::IsMatch(const Cluster *const pCluster) c
         if (momentumAtDca < std::numeric_limits<float>::epsilon())
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
-        const float eOverP(electromagneticEnergy / momentumAtDca);
+        const float eOverPEnergy(m_useCorrectedElectromagneticEnergyForEOverP ?
+            pCluster->GetCorrectedElectromagneticEnergy(this->GetPandora()) : electromagneticEnergy);
+        const float eOverP(eOverPEnergy / momentumAtDca);
 
         if (std::fabs(eOverP - 1.f) < m_maxResidualEOverP)
             return true;
@@ -424,6 +427,9 @@ StatusCode LCParticleIdPlugins::LCElectronId::ReadSettings(const TiXmlHandle xml
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MaxResidualEOverP", m_maxResidualEOverP));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseCorrectedElectromagneticEnergyForEOverP", m_useCorrectedElectromagneticEnergyForEOverP));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
@@ -127,12 +127,14 @@ StatusCode ConeBasedMergingAlgorithm::Run()
             if (sigmaE < std::numeric_limits<float>::epsilon())
                 return STATUS_CODE_FAILURE;
 
-            const float clusterEnergySum = (pBestParentCluster->GetHadronicEnergy() + pDaughterCluster->GetHadronicEnergy());
+            const float parentHadronicEnergy(pBestParentCluster->GetCorrectedHadronicEnergy(this->GetPandora()));
+            const float daughterHadronicEnergy(pDaughterCluster->GetCorrectedHadronicEnergy(this->GetPandora()));
+            const float clusterEnergySum(parentHadronicEnergy + daughterHadronicEnergy);
 
             const float chi((clusterEnergySum - trackEnergySum) / sigmaE);
-            const float chi0((pBestParentCluster->GetHadronicEnergy() - trackEnergySum) / sigmaE);
+            const float chi0((parentHadronicEnergy - trackEnergySum) / sigmaE);
 
-            if (pDaughterCluster->GetHadronicEnergy() > m_minDaughterHadronicEnergy)
+            if (daughterHadronicEnergy > m_minDaughterHadronicEnergy)
             {
                 if ((chi > m_maxTrackClusterChi) || ((chi * chi - chi0 * chi0) > m_maxTrackClusterDChi2))
                     continue;

--- a/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
@@ -32,6 +32,7 @@ ConeBasedMergingAlgorithm::ConeBasedMergingAlgorithm() :
     m_minDaughterHadronicEnergy(1.f),
     m_maxTrackClusterChi(2.5f),
     m_maxTrackClusterDChi2(1.f),
+    m_useCorrectedHadronicEnergyForTrackComparison(false),
     m_minCosConeAngleWrtRadial(0.25f),
     m_cosConeAngleWrtRadialCut1(0.5f),
     m_minHitSeparationCut1(std::sqrt(1000.f)),
@@ -129,19 +130,28 @@ StatusCode ConeBasedMergingAlgorithm::Run()
             if (sigmaE < std::numeric_limits<float>::epsilon())
                 return STATUS_CODE_FAILURE;
 
-            const float parentHadronicEnergy(pBestParentCluster->GetCorrectedHadronicEnergy(this->GetPandora()));
-            const float mergedHadronicEnergy(pBestParentCluster->GetHadronicEnergy() + pDaughterCluster->GetHadronicEnergy());
-            // Use the parent direction as the merged-cluster direction estimate; the daughter has passed the parent-cone test.
-            const CartesianVector &parentDirection(pBestParentCluster->GetFitToAllHitsResult().IsFitSuccessful() ?
-                pBestParentCluster->GetFitToAllHitsResult().GetDirection() : pBestParentCluster->GetInitialDirection());
-            const float mergedCorrectedHadronicEnergy(LCEnergyCorrectionPlugins::GetThetaEnergyCorrectedEnergy(
-                pandora::HADRONIC, parentDirection, mergedHadronicEnergy));
-            const float addedCorrectedHadronicEnergy(std::max(0.f, mergedCorrectedHadronicEnergy - parentHadronicEnergy));
+            float parentHadronicEnergy(pBestParentCluster->GetHadronicEnergy());
+            float mergedHadronicEnergy(parentHadronicEnergy + pDaughterCluster->GetHadronicEnergy());
+            float addedHadronicEnergy(pDaughterCluster->GetHadronicEnergy());
 
-            const float chi((mergedCorrectedHadronicEnergy - trackEnergySum) / sigmaE);
+            if (m_useCorrectedHadronicEnergyForTrackComparison)
+            {
+                parentHadronicEnergy = pBestParentCluster->GetCorrectedHadronicEnergy(this->GetPandora());
+                mergedHadronicEnergy = pBestParentCluster->GetHadronicEnergy() + pDaughterCluster->GetHadronicEnergy();
+
+                // Use the parent direction as the merged-cluster direction estimate; the daughter has passed the parent-cone test.
+                const CartesianVector &parentDirection(pBestParentCluster->GetFitToAllHitsResult().IsFitSuccessful() ?
+                    pBestParentCluster->GetFitToAllHitsResult().GetDirection() : pBestParentCluster->GetInitialDirection());
+
+                mergedHadronicEnergy = LCEnergyCorrectionPlugins::GetThetaEnergyCorrectedEnergy(pandora::HADRONIC,
+                    parentDirection, mergedHadronicEnergy);
+                addedHadronicEnergy = std::max(0.f, mergedHadronicEnergy - parentHadronicEnergy);
+            }
+
+            const float chi((mergedHadronicEnergy - trackEnergySum) / sigmaE);
             const float chi0((parentHadronicEnergy - trackEnergySum) / sigmaE);
 
-            if (addedCorrectedHadronicEnergy > m_minDaughterHadronicEnergy)
+            if (addedHadronicEnergy > m_minDaughterHadronicEnergy)
             {
                 if ((chi > m_maxTrackClusterChi) || ((chi * chi - chi0 * chi0) > m_maxTrackClusterDChi2))
                     continue;
@@ -312,6 +322,9 @@ StatusCode ConeBasedMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MaxTrackClusterDChi2", m_maxTrackClusterDChi2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseCorrectedHadronicEnergyForTrackComparison", m_useCorrectedHadronicEnergyForTrackComparison));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MinCosConeAngleWrtRadial", m_minCosConeAngleWrtRadial));

--- a/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/ConeBasedMergingAlgorithm.cc
@@ -11,6 +11,8 @@
 #include "LCHelpers/ClusterHelper.h"
 #include "LCHelpers/SortingHelper.h"
 
+#include "LCPlugins/LCEnergyCorrectionPlugins.h"
+
 #include "LCTopologicalAssociation/ConeBasedMergingAlgorithm.h"
 
 using namespace pandora;
@@ -128,13 +130,18 @@ StatusCode ConeBasedMergingAlgorithm::Run()
                 return STATUS_CODE_FAILURE;
 
             const float parentHadronicEnergy(pBestParentCluster->GetCorrectedHadronicEnergy(this->GetPandora()));
-            const float daughterHadronicEnergy(pDaughterCluster->GetCorrectedHadronicEnergy(this->GetPandora()));
-            const float clusterEnergySum(parentHadronicEnergy + daughterHadronicEnergy);
+            const float mergedHadronicEnergy(pBestParentCluster->GetHadronicEnergy() + pDaughterCluster->GetHadronicEnergy());
+            // Use the parent direction as the merged-cluster direction estimate; the daughter has passed the parent-cone test.
+            const CartesianVector &parentDirection(pBestParentCluster->GetFitToAllHitsResult().IsFitSuccessful() ?
+                pBestParentCluster->GetFitToAllHitsResult().GetDirection() : pBestParentCluster->GetInitialDirection());
+            const float mergedCorrectedHadronicEnergy(LCEnergyCorrectionPlugins::GetThetaEnergyCorrectedEnergy(
+                pandora::HADRONIC, parentDirection, mergedHadronicEnergy));
+            const float addedCorrectedHadronicEnergy(std::max(0.f, mergedCorrectedHadronicEnergy - parentHadronicEnergy));
 
-            const float chi((clusterEnergySum - trackEnergySum) / sigmaE);
+            const float chi((mergedCorrectedHadronicEnergy - trackEnergySum) / sigmaE);
             const float chi0((parentHadronicEnergy - trackEnergySum) / sigmaE);
 
-            if (daughterHadronicEnergy > m_minDaughterHadronicEnergy)
+            if (addedCorrectedHadronicEnergy > m_minDaughterHadronicEnergy)
             {
                 if ((chi > m_maxTrackClusterChi) || ((chi * chi - chi0 * chi0) > m_maxTrackClusterDChi2))
                     continue;

--- a/src/LCTopologicalAssociation/ProximityBasedMergingAlgorithm.cc
+++ b/src/LCTopologicalAssociation/ProximityBasedMergingAlgorithm.cc
@@ -12,6 +12,8 @@
 #include "LCHelpers/FragmentRemovalHelper.h"
 #include "LCHelpers/SortingHelper.h"
 
+#include "LCPlugins/LCEnergyCorrectionPlugins.h"
+
 #include "LCTopologicalAssociation/ProximityBasedMergingAlgorithm.h"
 
 using namespace pandora;
@@ -27,6 +29,7 @@ ProximityBasedMergingAlgorithm::ProximityBasedMergingAlgorithm() :
     m_minShowerLayerSpan(-4),
     m_maxTrackClusterChi(2.5f),
     m_maxTrackClusterDChi2(1.f),
+    m_useCorrectedHadronicEnergyForTrackComparison(false),
     m_nGenericDistanceLayers(5),
     m_maxGenericDistance(50.f),
     m_nAdjacentLayersToExamine(2),
@@ -129,10 +132,23 @@ StatusCode ProximityBasedMergingAlgorithm::Run()
                 if (sigmaE < std::numeric_limits<float>::epsilon())
                     return STATUS_CODE_FAILURE;
 
-                const float clusterEnergySum = (daughterHadronicEnergy + parentHadronicEnergy);
+                float parentTrackComparisonEnergy(parentHadronicEnergy);
+                float clusterEnergySum(daughterHadronicEnergy + parentHadronicEnergy);
+
+                if (m_useCorrectedHadronicEnergyForTrackComparison)
+                {
+                    parentTrackComparisonEnergy = pParentCluster->GetCorrectedHadronicEnergy(this->GetPandora());
+
+                    // Use the parent direction as the merged-cluster direction estimate for this daughter-candidate test.
+                    const CartesianVector &parentDirection(pParentCluster->GetFitToAllHitsResult().IsFitSuccessful() ?
+                        pParentCluster->GetFitToAllHitsResult().GetDirection() : pParentCluster->GetInitialDirection());
+
+                    clusterEnergySum = LCEnergyCorrectionPlugins::GetThetaEnergyCorrectedEnergy(pandora::HADRONIC,
+                        parentDirection, parentHadronicEnergy + daughterHadronicEnergy);
+                }
 
                 const float chi((clusterEnergySum - trackEnergySum) / sigmaE);
-                const float chi0((parentHadronicEnergy - trackEnergySum) / sigmaE);
+                const float chi0((parentTrackComparisonEnergy - trackEnergySum) / sigmaE);
 
                 if ((chi > m_maxTrackClusterChi) || ((chi * chi - chi0 * chi0) > m_maxTrackClusterDChi2))
                     continue;
@@ -327,6 +343,9 @@ StatusCode ProximityBasedMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHan
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MaxTrackClusterDChi2", m_maxTrackClusterDChi2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseCorrectedHadronicEnergyForTrackComparison", m_useCorrectedHadronicEnergyForTrackComparison));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "NGenericDistanceLayers", m_nGenericDistanceLayers));

--- a/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
+++ b/src/LCTrackClusterAssociation/TrackClusterAssociationAlgorithm.cc
@@ -45,7 +45,8 @@ TrackClusterAssociationAlgorithm::TrackClusterAssociationAlgorithm() :
     m_maxTrackClusterDistance(10.f),
     m_maxSearchLayer(9),
     m_parallelDistanceCut(100.f),
-    m_minTrackClusterCosAngle(0.f)
+    m_minTrackClusterCosAngle(0.f),
+    m_useCorrectedHadronicEnergyForTrackComparison(false)
 {
 }
 
@@ -184,9 +185,12 @@ StatusCode TrackClusterAssociationAlgorithm::Run()
                     continue;
                 }
 
-                const float energyDifference(std::fabs(pCluster->GetHadronicEnergy() - pTrack->GetEnergyAtDca()));
+                const float clusterHadronicEnergy(pCluster->GetHadronicEnergy());
+                const float trackComparisonEnergy(m_useCorrectedHadronicEnergyForTrackComparison ?
+                    pCluster->GetCorrectedHadronicEnergy(this->GetPandora()) : clusterHadronicEnergy);
+                const float energyDifference(std::fabs(trackComparisonEnergy - pTrack->GetEnergyAtDca()));
 
-                if (pCluster->GetHadronicEnergy() > m_lowEnergyCut)
+                if (clusterHadronicEnergy > m_lowEnergyCut)
                 {
                     if ((trackClusterDistance < minDistance) || ((trackClusterDistance == minDistance) && (energyDifference < minEnergyDifference)))
                     {
@@ -246,6 +250,9 @@ StatusCode TrackClusterAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlH
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MinTrackClusterCosAngle", m_minTrackClusterCosAngle));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseCorrectedHadronicEnergyForTrackComparison", m_useCorrectedHadronicEnergyForTrackComparison));
 
     return STATUS_CODE_SUCCESS;
 }


### PR DESCRIPTION
These commits are from @trholmes. I am submitting a PR because downstream
work depends on them.

Adds two energy correction plugins that look up a correction factor in a 2D
(theta, energy) table instead of applying one flat constant per subdetector:

- PhotonEMNonLinearity, electromagnetic
- HadronicThetaEnergyBinned, hadronic

The correction is applied inside Pandora, after clustering and before PFOs are
built, so cluster energies, PFO energies, and jets all come out consistent and
nothing has to be applied by hand downstream.

Also adds a three-argument RegisterNonLinearityEnergyCorrection overload taking
the bin edges and the table. The existing one-argument overload is unchanged,
and with no table supplied the plugins fall back to it, which is the identity.
So this is a no-op for anyone who does not configure a table.

These plugins have been in use in muon collider reconstruction and are being
upstreamed so they are available generally. key4hep/k4GaudiPandora#51 uses this
overload and cannot compile until this lands, and
MuonColliderSoft/MAIAConfig#90 sits on top of that. 
This is a draft for now. This needs a rebase onto current master before it can be merged. Opening it so the dependency chain is visible.